### PR TITLE
Events improvement

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.1</string>
+	<string>3.1.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/ReactiveDataDisplayManager.podspec
+++ b/ReactiveDataDisplayManager.podspec
@@ -1,8 +1,7 @@
 Pod::Spec.new do |s|
   s.name = "ReactiveDataDisplayManager"
-  s.version = "3.1.1"
-  s.summary = "Library with custom events and reusable adapter for UI Collectionclear
-  "
+  s.version = "3.1.2"
+  s.summary = "Library with custom events and reusable adapter for UI Collections"
   s.homepage = "https://github.com/surfstudio/ReactiveDataDisplayManager"
   s.license = "MIT"
   s.author = { "Alexander Kravchenkov" => "sprintend@gmail.com" }

--- a/Source/Utils/Event.swift
+++ b/Source/Utils/Event.swift
@@ -62,7 +62,10 @@ public class BaseEvent<Input>: Event {
 
     public typealias Lambda = (Input) -> Void
 
-    public static func += (left: BaseEvent<Input>, right: @escaping Lambda) {
+    public static func += (left: BaseEvent<Input>, right: Lambda?) {
+        guard let right = right else {
+            return
+        }
         left.addListner(right)
     }
 


### PR DESCRIPTION
**Changes:**
Change non-optional right parameter of `+=` method in BaseEvent to optional

Now we will be able to write like this:

```swift
var optionalClosure: ((String) -> Void)?

func configure(with model: Model) {
    let generator = CellGenerator(model: model)
    // In previous version in line below would be error:
    // Value of optional type '((String) -> Void)?' must be unwrapped to a value of type '(String) -> Void'
    contactsGenerator.nonOptionalEvent += optionalClosure 
}
```