### PR TITLE
BaseCellGenerator resolves surfstudio/ReactiveDataDisplayManager#37

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.2</string>
+	<string>3.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/ReactiveDataDisplayManager.podspec
+++ b/ReactiveDataDisplayManager.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "ReactiveDataDisplayManager"
-  s.version = "3.1.2"
+  s.version = "3.2.0"
   s.summary = "Library with custom events and reusable adapter for UI Collections"
   s.homepage = "https://github.com/surfstudio/ReactiveDataDisplayManager"
   s.license = "MIT"

--- a/ReactiveDataDisplayManager.xcodeproj/project.pbxproj
+++ b/ReactiveDataDisplayManager.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		4F088BF91F4EABA2006B7809 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F088BF81F4EABA2006B7809 /* UIKit.framework */; };
 		4FD38130202D6F510005EBFE /* DataDisplayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD3812F202D6F510005EBFE /* DataDisplayManager.swift */; };
 		4FD38132202D791A0005EBFE /* Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD38131202D791A0005EBFE /* Operations.swift */; };
+		8632735D21F0F7DA00620CEE /* ConfigurableProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8632735C21F0F7DA00620CEE /* ConfigurableProtocol.swift */; };
 		86F35A2C21EE7B51009D3001 /* BaseCellGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F35A2B21EE7B51009D3001 /* BaseCellGenerator.swift */; };
 		8B7E264D20B898D1001D7A93 /* XCTestCase+FatalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7E264C20B898D1001D7A93 /* XCTestCase+FatalError.swift */; };
 		8B7E265220B89B12001D7A93 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F088BEA1F4E9F74006B7809 /* Event.swift */; };
@@ -46,6 +47,7 @@
 		4F088BF81F4EABA2006B7809 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		4FD3812F202D6F510005EBFE /* DataDisplayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataDisplayManager.swift; sourceTree = "<group>"; };
 		4FD38131202D791A0005EBFE /* Operations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operations.swift; sourceTree = "<group>"; };
+		8632735C21F0F7DA00620CEE /* ConfigurableProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableProtocol.swift; sourceTree = "<group>"; };
 		86F35A2B21EE7B51009D3001 /* BaseCellGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCellGenerator.swift; sourceTree = "<group>"; };
 		8B7E264C20B898D1001D7A93 /* XCTestCase+FatalError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FatalError.swift"; sourceTree = "<group>"; };
 		8B7E264E20B89AE0001D7A93 /* FatalErrorUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FatalErrorUtil.swift; sourceTree = "<group>"; };
@@ -132,8 +134,9 @@
 		8BAB778E20BB45C50005C4E9 /* Support */ = {
 			isa = PBXGroup;
 			children = (
-				8BAB778C20BB45B90005C4E9 /* EmptyHeaderGenerator.swift */,
 				86F35A2B21EE7B51009D3001 /* BaseCellGenerator.swift */,
+				8632735C21F0F7DA00620CEE /* ConfigurableProtocol.swift */,
+				8BAB778C20BB45B90005C4E9 /* EmptyHeaderGenerator.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -301,6 +304,7 @@
 				86F35A2C21EE7B51009D3001 /* BaseCellGenerator.swift in Sources */,
 				8BAB778D20BB45B90005C4E9 /* EmptyHeaderGenerator.swift in Sources */,
 				4F088BF31F4E9F74006B7809 /* Protocols.swift in Sources */,
+				8632735D21F0F7DA00620CEE /* ConfigurableProtocol.swift in Sources */,
 				4FD38132202D791A0005EBFE /* Operations.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ReactiveDataDisplayManager.xcodeproj/project.pbxproj
+++ b/ReactiveDataDisplayManager.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		4F088BF91F4EABA2006B7809 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F088BF81F4EABA2006B7809 /* UIKit.framework */; };
 		4FD38130202D6F510005EBFE /* DataDisplayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD3812F202D6F510005EBFE /* DataDisplayManager.swift */; };
 		4FD38132202D791A0005EBFE /* Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD38131202D791A0005EBFE /* Operations.swift */; };
+		86F35A2C21EE7B51009D3001 /* BaseCellGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F35A2B21EE7B51009D3001 /* BaseCellGenerator.swift */; };
 		8B7E264D20B898D1001D7A93 /* XCTestCase+FatalError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7E264C20B898D1001D7A93 /* XCTestCase+FatalError.swift */; };
 		8B7E265220B89B12001D7A93 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F088BEA1F4E9F74006B7809 /* Event.swift */; };
 		8B7E265320B89B15001D7A93 /* FatalErrorUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7E264E20B89AE0001D7A93 /* FatalErrorUtil.swift */; };
@@ -45,6 +46,7 @@
 		4F088BF81F4EABA2006B7809 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		4FD3812F202D6F510005EBFE /* DataDisplayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataDisplayManager.swift; sourceTree = "<group>"; };
 		4FD38131202D791A0005EBFE /* Operations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operations.swift; sourceTree = "<group>"; };
+		86F35A2B21EE7B51009D3001 /* BaseCellGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCellGenerator.swift; sourceTree = "<group>"; };
 		8B7E264C20B898D1001D7A93 /* XCTestCase+FatalError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FatalError.swift"; sourceTree = "<group>"; };
 		8B7E264E20B89AE0001D7A93 /* FatalErrorUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FatalErrorUtil.swift; sourceTree = "<group>"; };
 		8BAB778620BB41120005C4E9 /* PaginableBaseTableDataDisplayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginableBaseTableDataDisplayManager.swift; sourceTree = "<group>"; };
@@ -131,6 +133,7 @@
 			isa = PBXGroup;
 			children = (
 				8BAB778C20BB45B90005C4E9 /* EmptyHeaderGenerator.swift */,
+				86F35A2B21EE7B51009D3001 /* BaseCellGenerator.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -295,6 +298,7 @@
 				4F088BF11F4E9F74006B7809 /* Extensions.swift in Sources */,
 				4F088BEF1F4E9F74006B7809 /* BaseTableDataDisplayManager.swift in Sources */,
 				8BAB778920BB41260005C4E9 /* ExtendableBaseTableDataDisplayManager.swift in Sources */,
+				86F35A2C21EE7B51009D3001 /* BaseCellGenerator.swift in Sources */,
 				8BAB778D20BB45B90005C4E9 /* EmptyHeaderGenerator.swift in Sources */,
 				4F088BF31F4E9F74006B7809 /* Protocols.swift in Sources */,
 				4FD38132202D791A0005EBFE /* Operations.swift in Sources */,

--- a/Source/BaseTableDataDisplayManager/Support/BaseCellGenerator.swift
+++ b/Source/BaseTableDataDisplayManager/Support/BaseCellGenerator.swift
@@ -8,15 +8,6 @@
 
 import Foundation
 
-/// Protocol for UITableViewCell which is supposed to be used in BaseCellGenerator
-public protocol Configurable where Self: UITableViewCell {
-
-    associatedtype Model
-
-    func configure(with model: Model)
-
-}
-
 public class BaseCellGenerator<Cell: Configurable>: SelectableItem {
 
     // MARK: - Properties
@@ -26,11 +17,13 @@ public class BaseCellGenerator<Cell: Configurable>: SelectableItem {
     // MARK: - Private properties
 
     private let model: Cell.Model
+    private let registerClass: Bool
 
     // MARK: - Initialization
 
-    public init(with model: Cell.Model) {
+    public init(with model: Cell.Model, registerClass: Bool = false) {
         self.model = model
+        self.registerClass = registerClass
     }
 
 }
@@ -52,7 +45,11 @@ extension BaseCellGenerator: TableCellGenerator {
     }
 
     public func registerCell(in tableView: UITableView) {
-        tableView.registerNib(identifier)
+        if registerClass {
+            tableView.register(identifier, forCellReuseIdentifier: identifier.nameOfClass)
+        } else {
+            tableView.registerNib(identifier)
+        }
     }
 
 }

--- a/Source/BaseTableDataDisplayManager/Support/BaseCellGenerator.swift
+++ b/Source/BaseTableDataDisplayManager/Support/BaseCellGenerator.swift
@@ -1,0 +1,58 @@
+//
+//  BaseCellGenerator.swift
+//  ReactiveDataDisplayManager
+//
+//  Created by Mikhail Monakov on 15/01/2019.
+//  Copyright © 2019 Александр Кравченков. All rights reserved.
+//
+
+import Foundation
+
+/// Protocol for UITableViewCell which is supposed to be used in BaseCellGenerator
+public protocol Configurable where Self: UITableViewCell {
+
+    associatedtype Model
+
+    func configure(with model: Model)
+
+}
+
+public class BaseCellGenerator<Cell: Configurable>: SelectableItem {
+
+    // MARK: - Properties
+
+    public var didSelectEvent = BaseEvent<Void>()
+
+    // MARK: - Private properties
+
+    private let model: Cell.Model
+
+    // MARK: - Initialization
+
+    public init(with model: Cell.Model) {
+        self.model = model
+    }
+
+}
+
+// MARK: - TableCellGenerator
+
+extension BaseCellGenerator: TableCellGenerator {
+
+    public var identifier: UITableViewCell.Type {
+        return Cell.self
+    }
+
+    public func generate(tableView: UITableView, for indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: identifier.nameOfClass, for: indexPath) as? Cell else {
+            return UITableViewCell()
+        }
+        cell.configure(with: model)
+        return cell
+    }
+
+    public func registerCell(in tableView: UITableView) {
+        tableView.registerNib(identifier)
+    }
+
+}

--- a/Source/BaseTableDataDisplayManager/Support/ConfigurableProtocol.swift
+++ b/Source/BaseTableDataDisplayManager/Support/ConfigurableProtocol.swift
@@ -1,0 +1,18 @@
+//
+//  ConfigurableProtocol.swift
+//  ReactiveDataDisplayManager
+//
+//  Created by Mikhail Monakov on 17/01/2019.
+//  Copyright © 2019 Александр Кравченков. All rights reserved.
+//
+
+import Foundation
+
+/// Protocol for UITableViewCell which is supposed to be used in BaseCellGenerator
+public protocol Configurable where Self: UITableViewCell {
+
+    associatedtype Model
+
+    func configure(with model: Model)
+    
+}


### PR DESCRIPTION
Implementation of BaseCellGenerator to avoid boilerplate code.
How to use: 
```swift
class ConfigurableCell: UITableViewCell, Configurable { 

    func configure(with anyModel: String) {
        // use anyModel here
    }

}
let generator = BaseCellGenerator<ConfigurableCell>(with: anyModel)
```