### PR TITLE
fix swift version

### DIFF
--- a/ReactiveDataDisplayManager.podspec
+++ b/ReactiveDataDisplayManager.podspec
@@ -10,5 +10,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Source/**/*.swift'
   s.framework = 'UIKit'
   s.ios.deployment_target = '9.0'
-
+  s.swift_version = '4.2'
 end


### PR DESCRIPTION
So as swift version was not fixed for this .spec, pod swift version sets the same as project version (in case project uses swift 4 it will not compile). 

As example: Example project in this repo currently does not compile because of this 