### PR TITLE
make estimated height optional

### DIFF
--- a/Source/BaseTableDataDisplayManager/BaseTableDataDisplayManager.swift
+++ b/Source/BaseTableDataDisplayManager/BaseTableDataDisplayManager.swift
@@ -34,7 +34,7 @@ open class BaseTableDataDisplayManager: NSObject, DataDisplayManager {
 
     // MARK: - Public properties
 
-    public var estimatedHeight: CGFloat?
+    public var estimatedHeight: CGFloat = 40
 
     // MARK: - Initialization and deinitialization
 
@@ -328,7 +328,7 @@ extension BaseTableDataDisplayManager: UITableViewDelegate {
     }
 
     open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return self.estimatedHeight ?? cellGenerators[indexPath.section][indexPath.row].heightForCell()
+        return cellGenerators[indexPath.section][indexPath.row].estimatedHeightForCell() ?? estimatedHeight
     }
 
     open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/Source/BaseTableDataDisplayManager/BaseTableDataDisplayManager.swift
+++ b/Source/BaseTableDataDisplayManager/BaseTableDataDisplayManager.swift
@@ -324,11 +324,11 @@ extension BaseTableDataDisplayManager: UITableViewDelegate {
     }
 
     open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return cellGenerators[indexPath.section][indexPath.row].heightForCell()
+        return cellGenerators[indexPath.section][indexPath.row].cellHeight
     }
 
     open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return cellGenerators[indexPath.section][indexPath.row].estimatedHeightForCell() ?? estimatedHeight
+        return cellGenerators[indexPath.section][indexPath.row].estimatedCellHeight ?? estimatedHeight
     }
 
     open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/Source/BaseTableDataDisplayManager/BaseTableDataDisplayManager.swift
+++ b/Source/BaseTableDataDisplayManager/BaseTableDataDisplayManager.swift
@@ -34,7 +34,7 @@ open class BaseTableDataDisplayManager: NSObject, DataDisplayManager {
 
     // MARK: - Public properties
 
-    public var estimatedHeight: CGFloat = 40
+    public var estimatedHeight: CGFloat?
 
     // MARK: - Initialization and deinitialization
 
@@ -328,7 +328,7 @@ extension BaseTableDataDisplayManager: UITableViewDelegate {
     }
 
     open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return self.estimatedHeight
+        return self.estimatedHeight ?? cellGenerators[indexPath.section][indexPath.row].heightForCell()
     }
 
     open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/Source/Protocols.swift
+++ b/Source/Protocols.swift
@@ -43,6 +43,11 @@ public protocol TableCellGenerator: class {
     ///
     /// Default implementation returns UITableView.automaticDimension
     func heightForCell() -> CGFloat
+
+    /// Returns estimated height for cell
+    ///
+    /// Default implementation returns nil
+    func estimatedHeightForCell() -> CGFloat?
 }
 
 
@@ -127,6 +132,10 @@ public extension TableCellGenerator {
 
     func heightForCell() -> CGFloat {
         return UITableView.automaticDimension
+    }
+
+    func estimatedHeightForCell() -> CGFloat? {
+        return nil
     }
 
 }

--- a/Source/Protocols.swift
+++ b/Source/Protocols.swift
@@ -39,15 +39,15 @@ public protocol TableCellGenerator: class {
     /// - Parameter in: TableView, in which cell will be registered
     func registerCell(in tableView: UITableView)
 
-    /// Returns height for cell.
+    /// Height for cell.
     ///
     /// Default implementation returns UITableView.automaticDimension
-    func heightForCell() -> CGFloat
+    var cellHeight: CGFloat { get }
 
-    /// Returns estimated height for cell
+    /// Estimated height for cell
     ///
     /// Default implementation returns nil
-    func estimatedHeightForCell() -> CGFloat?
+    var estimatedCellHeight: CGFloat? { get }
 }
 
 
@@ -130,11 +130,11 @@ public extension SelectableItem {
 
 public extension TableCellGenerator {
 
-    func heightForCell() -> CGFloat {
+    var cellHeight: CGFloat {
         return UITableView.automaticDimension
     }
 
-    func estimatedHeightForCell() -> CGFloat? {
+    var estimatedCellHeight: CGFloat? {
         return nil
     }
 


### PR DESCRIPTION
In some animated cases such as insertion, deletion and replacement of cells which has different heights, fixed estimated value causes "jumps" because tableview could not calculate the exact heights for new state. 

Setting estimated variable to nil and providing exact .heightForCell() value improves animation process