### PR TITLE
Set correct bundle for register nib methods

### DIFF
--- a/Source/Utils/Extensions.swift
+++ b/Source/Utils/Extensions.swift
@@ -16,20 +16,20 @@ public extension NSObject {
 }
 
 public extension UIViewController {
-    public class func controller() -> Self {
+    class func controller() -> Self {
         let classReference = self.self
-        return classReference.init(nibName: self.nameOfClass, bundle: nil)
+        return classReference.init(nibName: self.nameOfClass, bundle: Bundle(for: self))
     }
 }
 
 public extension UITableView {
-    public func registerNib(_ cellType: UITableViewCell.Type) {
-        self.register(UINib(nibName: cellType.nameOfClass, bundle: nil), forCellReuseIdentifier: cellType.nameOfClass)
+    func registerNib(_ cellType: UITableViewCell.Type) {
+        self.register(UINib(nibName: cellType.nameOfClass, bundle: Bundle(for: cellType.self)), forCellReuseIdentifier: cellType.nameOfClass)
     }
 }
 
 public extension UICollectionView {
-    public func registerNib(_ cellType: UICollectionViewCell.Type) {
-        self.register(UINib(nibName: cellType.nameOfClass, bundle: nil), forCellWithReuseIdentifier: cellType.nameOfClass)
+    func registerNib(_ cellType: UICollectionViewCell.Type) {
+        self.register(UINib(nibName: cellType.nameOfClass, bundle: Bundle(for: cellType.self)), forCellWithReuseIdentifier: cellType.nameOfClass)
     }
 }


### PR DESCRIPTION
Сори, если как-то некорректно пытаюсь контрибьютить к вам, первый раз сюда заглянул.    

Короче у меня проблема с этими методами, так как они публичные в RDDM, все мое любимое приложение использует эти методы для регистрации ячеек в коллекциях.      

А я тут начал короче настоящую модульность делать в своем любимом приложение, и для корректной инициализации ячейки из nib файла необходимо указывать конкретный бандл, в котором оно лежит. 

Собственно в методах я явно указал при получение nib файла необходимо найти бандл для этого класса. 

Для проектов без бандлов ничего не поменяется, просто будет возвращаться main бандл для этого класса