### PR TITLE
DisplayableFlow update

### DIFF
--- a/Source/BaseTableDataDisplayManager/BaseTableDataDisplayManager.swift
+++ b/Source/BaseTableDataDisplayManager/BaseTableDataDisplayManager.swift
@@ -584,6 +584,7 @@ extension BaseTableDataDisplayManager: UITableViewDelegate {
         self.didEndDisplayCellEvent.invoke(with: (generator, indexPath))
         if let displayable = generator as? DisplayableFlow {
             displayable.didEndDisplayEvent.invoke(with: ())
+            displayable.didEndDisplayCellEvent?.invoke(with: cell)
         }
     }
 

--- a/Source/Protocols/Protocols.swift
+++ b/Source/Protocols/Protocols.swift
@@ -129,8 +129,13 @@ public protocol DisplayableFlow: class {
     /// Invokes when cell will displaying.
     var willDisplayEvent: BaseEvent<Void> { get }
 
+    /// SORTA DEPRECATED
     /// Invokes when cell did end displaying.
     var didEndDisplayEvent: BaseEvent<Void> { get }
+
+    /// Invokes when cell did end displaying. (Replacement for didEndDisplayEvent:; makes cell management easier.)
+    /// To be clear, it is just a workaround.
+    var didEndDisplayCellEvent: BaseEvent<UITableViewCell>? { get }
 
 }
 


### PR DESCRIPTION
# Что сделано
- DisplayableFlow расширен для возможности получать конкретные ячейки вместе с событием ухода ячейки из таблицы.
- Старый `var` оставлен для обратной совместимости.

# Для чего сделано
В некоторых сценариях генераторы могут захватывать активную ячейку, но при этом из-за особенностей реализации RDDM уведомление о life cycle ячеек (willDisplay и didEndDisplay) могут приходить с заметной задержкой, из-за чего необходим способ понять, для какой именно UITableViewCell был исполнен блок `didEndDisplayEvent`. Конкретный пример: блок может быть исполнен в тот момент, когда старая ячейка в генераторе уже заменена на новую, и нам нужно будет отсечь обновление данных в таком сценарии, потому что блок предназначался старой ячейке.