### PR TITLE
update Paginatable plugin example

### DIFF
--- a/Example/ReactiveDataDisplayManager/Base.lproj/Main.storyboard
+++ b/Example/ReactiveDataDisplayManager/Base.lproj/Main.storyboard
@@ -234,7 +234,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="3Mp-mm-nX6">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="3Mp-mm-nX6">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
@@ -255,7 +255,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="XCn-cg-Cmd"/>
                     <connections>
-                        <outlet property="activityIndicator" destination="ede-WP-XvI" id="zeH-b7-whI"/>
+                        <outlet property="activityIndicator" destination="ede-WP-XvI" id="4BD-Iy-9rs"/>
                         <outlet property="tableView" destination="3Mp-mm-nX6" id="LjJ-Q1-2Ac"/>
                     </connections>
                 </viewController>

--- a/Example/ReactiveDataDisplayManager/Base.lproj/Main.storyboard
+++ b/Example/ReactiveDataDisplayManager/Base.lproj/Main.storyboard
@@ -238,10 +238,15 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
+                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="ede-WP-XvI">
+                                <rect key="frame" x="177.5" y="299" width="20" height="20"/>
+                            </activityIndicatorView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="VfY-IR-WY2"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="ede-WP-XvI" firstAttribute="centerY" secondItem="VfY-IR-WY2" secondAttribute="centerY" id="5Xm-Eb-dND"/>
+                            <constraint firstItem="ede-WP-XvI" firstAttribute="centerX" secondItem="VfY-IR-WY2" secondAttribute="centerX" id="75v-83-MJT"/>
                             <constraint firstItem="3Mp-mm-nX6" firstAttribute="leading" secondItem="VfY-IR-WY2" secondAttribute="leading" id="OTv-By-Z65"/>
                             <constraint firstItem="VfY-IR-WY2" firstAttribute="trailing" secondItem="3Mp-mm-nX6" secondAttribute="trailing" id="RXj-hS-oZs"/>
                             <constraint firstItem="VfY-IR-WY2" firstAttribute="bottom" secondItem="3Mp-mm-nX6" secondAttribute="bottom" id="wtg-Yd-gEW"/>
@@ -250,6 +255,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="XCn-cg-Cmd"/>
                     <connections>
+                        <outlet property="activityIndicator" destination="ede-WP-XvI" id="zeH-b7-whI"/>
                         <outlet property="tableView" destination="3Mp-mm-nX6" id="LjJ-Q1-2Ac"/>
                     </connections>
                 </viewController>

--- a/Example/ReactiveDataDisplayManager/Table/PaginatableTableViewController/PaginatableTableViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Table/PaginatableTableViewController/PaginatableTableViewController.swift
@@ -21,7 +21,8 @@ final class PaginatableTableViewController: UIViewController {
     // MARK: - IBOutlet
 
     @IBOutlet private weak var tableView: UITableView!
-
+    @IBOutlet private weak var activityIndicator: UIActivityIndicatorView!
+    
     // MARK: - Private Properties
 
     private lazy var progressView = PaginatorView(frame: .init(x: 0, y: 0, width: tableView.frame.width, height: 80))
@@ -31,6 +32,8 @@ final class PaginatableTableViewController: UIViewController {
                                   output: self))
         .build()
 
+    private weak var paginatableInput: PaginatableInput?
+
     private var currentPage = 0
 
     // MARK: - UIViewController
@@ -38,7 +41,7 @@ final class PaginatableTableViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Table with pagination"
-        fillAdapter()
+        loadFirstPage()
     }
 
 }
@@ -46,6 +49,21 @@ final class PaginatableTableViewController: UIViewController {
 // MARK: - Private Methods
 
 private extension PaginatableTableViewController {
+
+    func loadFirstPage() {
+
+        activityIndicator.isHidden = false
+        activityIndicator.startAnimating()
+
+        paginatableInput?.updatePagination(canIterate: false)
+
+        delay(.now() + .seconds(3)) { [weak self] in
+            self?.fillAdapter()
+            self?.activityIndicator?.stopAnimating()
+            self?.activityIndicator?.isHidden = true
+            self?.paginatableInput?.updatePagination(canIterate: true)
+        }
+    }
 
     /// This method is used to fill adapter
     func fillAdapter() {
@@ -55,8 +73,6 @@ private extension PaginatableTableViewController {
         }
 
         adapter.forceRefill()
-
-
     }
 
     func delay(_ deadline: DispatchTime, completion: @escaping () -> Void) {
@@ -90,11 +106,15 @@ private extension PaginatableTableViewController {
 
 extension PaginatableTableViewController: PaginatableOutput {
 
+    func onPaginationInitialized(with input: PaginatableInput) {
+        paginatableInput = input
+    }
+
     func loadNextPage(with input: PaginatableInput) {
         delay(.now() + .seconds(3)) { [weak self, weak input] in
             let canIterate = self?.fillNext() ?? false
 
-            input?.endLoading(canIterate: canIterate)
+            input?.updatePagination(canIterate: canIterate)
         }
     }
 

--- a/Example/ReactiveDataDisplayManager/Table/PaginatableTableViewController/PaginatableTableViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Table/PaginatableTableViewController/PaginatableTableViewController.swift
@@ -22,7 +22,7 @@ final class PaginatableTableViewController: UIViewController {
 
     @IBOutlet private weak var tableView: UITableView!
     @IBOutlet private weak var activityIndicator: UIActivityIndicatorView!
-    
+
     // MARK: - Private Properties
 
     private lazy var progressView = PaginatorView(frame: .init(x: 0, y: 0, width: tableView.frame.width, height: 80))
@@ -120,9 +120,13 @@ extension PaginatableTableViewController: PaginatableOutput {
     }
 
     func loadNextPage(with input: PaginatableInput) {
+
+        input.updateProgress(isLoading: true)
+
         delay(.now() + .seconds(3)) { [weak self, weak input] in
             let canIterate = self?.fillNext() ?? false
 
+            input?.updateProgress(isLoading: false)
             input?.updatePagination(canIterate: canIterate)
         }
     }

--- a/Example/ReactiveDataDisplayManager/Table/PaginatableTableViewController/PaginatableTableViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Table/PaginatableTableViewController/PaginatableTableViewController.swift
@@ -52,15 +52,24 @@ private extension PaginatableTableViewController {
 
     func loadFirstPage() {
 
+        // show loader
         activityIndicator.isHidden = false
         activityIndicator.startAnimating()
 
+        // hide footer
         paginatableInput?.updatePagination(canIterate: false)
 
+        // imitation of loading first page
         delay(.now() + .seconds(3)) { [weak self] in
+
+            // fill table
             self?.fillAdapter()
+
+            // hide loader
             self?.activityIndicator?.stopAnimating()
             self?.activityIndicator?.isHidden = true
+
+            // show footer
             self?.paginatableInput?.updatePagination(canIterate: true)
         }
     }

--- a/Source/REFACTORING/Table/Plugins/PluginAction/TablePaginatablePlugin.swift
+++ b/Source/REFACTORING/Table/Plugins/PluginAction/TablePaginatablePlugin.swift
@@ -18,10 +18,15 @@ public protocol ProgressDisplayableItem {
 /// Input signals to control visibility of progressView in footer
 public protocol PaginatableInput: class {
 
-    /// Call it to control visibility of progressView in footer
+    /// Call this method to control availability of **loadNextPage** action
     ///
-    /// - parameter canIterate: `true` if want to show `progressView` in footer
+    /// - parameter canIterate: `true` if want to use last cell will display event to execute **loadNextPage** action
     func updatePagination(canIterate: Bool)
+
+    /// Call this method to control visibility of progressView in footer
+    ///
+    /// - parameter isLoading: `true` if want to show `progressView` in footer
+    func updateProgress(isLoading: Bool)
 }
 
 /// Output signals for loading next page of content
@@ -93,7 +98,6 @@ public class TablePaginatablePlugin: BaseTablePlugin<TableEvent>  {
 
             let lastCellIndexPath = IndexPath(row: lastCellInLastSectionIndex, section: lastSectionIndex)
             if indexPath == lastCellIndexPath && canIterate {
-                progressView.showProgress(true)
                 output?.loadNextPage(with: self)
             }
         default:
@@ -107,8 +111,11 @@ public class TablePaginatablePlugin: BaseTablePlugin<TableEvent>  {
 
 extension TablePaginatablePlugin: PaginatableInput {
 
+    public func updateProgress(isLoading: Bool) {
+        progressView.showProgress(isLoading)
+    }
+
     public func updatePagination(canIterate: Bool) {
-        progressView.showProgress(false)
         self.canIterate = canIterate
     }
 

--- a/Source/REFACTORING/Table/Plugins/PluginAction/TablePaginatablePlugin.swift
+++ b/Source/REFACTORING/Table/Plugins/PluginAction/TablePaginatablePlugin.swift
@@ -21,11 +21,16 @@ public protocol PaginatableInput: class {
     /// Call it to control visibility of progressView in footer
     ///
     /// - parameter canIterate: `true` if want to show `progressView` in footer
-    func endLoading(canIterate: Bool)
+    func updatePagination(canIterate: Bool)
 }
 
 /// Output signals for loading next page of content
 public protocol PaginatableOutput: class {
+
+    /// Called when collection has setup `TablePaginatablePlugin`
+    ///
+    /// - parameter input: input signals to hide  `progressView` from footer
+    func onPaginationInitialized(with input: PaginatableInput)
 
     /// Called when collection scrolled to last cell
     ///
@@ -49,7 +54,7 @@ public class TablePaginatablePlugin: BaseTablePlugin<TableEvent>  {
     private weak var tableView: UITableView?
 
     /// Property which indicating availability of pages
-    public private(set) var canIterate = true {
+    public private(set) var canIterate = false {
         didSet {
             if canIterate {
                 tableView?.tableFooterView = progressView
@@ -72,7 +77,8 @@ public class TablePaginatablePlugin: BaseTablePlugin<TableEvent>  {
 
     public override func setup(with manager: BaseTableManager?) {
         self.tableView = manager?.view
-        self.canIterate = true
+        self.canIterate = false
+        self.output?.onPaginationInitialized(with: self)
     }
 
     public override func process(event: TableEvent, with manager: BaseTableManager?) {
@@ -101,7 +107,7 @@ public class TablePaginatablePlugin: BaseTablePlugin<TableEvent>  {
 
 extension TablePaginatablePlugin: PaginatableInput {
 
-    public func endLoading(canIterate: Bool) {
+    public func updatePagination(canIterate: Bool) {
         progressView.showProgress(false)
         self.canIterate = canIterate
     }


### PR DESCRIPTION
## Что сделано?

- Расширен `PaginatableOutput` чтобы можно было управлять признаком `canIterate` раньше
- Переименованы методы `PaginatableOutput`
- Обновлен пример, чтобы иллюстрировать более реальную ситуацию
- ...

## Зачем это сделано?

Фиксим недоработку.
При использовании плагина столкнулись с проблемой, что на начальном этапе (загрузка первой страницы) надо проставить canIterate false и потом вернуть. Это было невозможно сделать

## На что обратить внимание?

- ...

## Как протестировать?

- Тапнуть в примере на строчку table with pagination
