### PR TITLE
IDPT-814 RDDM. Добавить стратегии ограничения дропа в drag'n'dropable plugin

### DIFF
--- a/Example/ReactiveDataDisplayManager/Collection/DragAndDroppableCollectionViewController/DragAndDroppableCollectionViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Collection/DragAndDroppableCollectionViewController/DragAndDroppableCollectionViewController.swift
@@ -15,6 +15,8 @@ final class DragAndDroppableCollectionViewController: UIViewController {
     private enum Constants {
         static let sectionInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
         static let cellSize = CGSize(width: 120, height: 120)
+        static let titleForSectionFirst = "SectionFirst"
+        static let titleForSectionLast = "SectionLast"
     }
 
     // MARK: - IBOutlets
@@ -24,7 +26,8 @@ final class DragAndDroppableCollectionViewController: UIViewController {
     // MARK: - Private Properties
 
     private lazy var adapter = collectionView.rddm.baseBuilder
-        .add(featurePlugin: .dragAndDroppable())
+        .set(delegate: FlowCollectionDelegate())
+        .add(featurePlugin: .dragAndDroppable(by: .current))
         .build()
 
     // MARK: - UIViewController
@@ -58,21 +61,21 @@ private extension DragAndDroppableCollectionViewController {
 
     /// This method is used to fill adapter
     func fillAdapter() {
-        // Create cell generators
-        let generators = makeCellGenerators()
-
-        // Add cell generators to adapter
-        adapter.addCellGenerators(generators)
+        // Add generators to adapter
+        adapter.addSectionHeaderGenerator(TitleCollectionHeaderGenerator(title: Constants.titleForSectionFirst))
+        adapter.addCellGenerators(makeCellGenerators(for: Array(1...10)))
+        adapter.addSectionHeaderGenerator(TitleCollectionHeaderGenerator(title: Constants.titleForSectionLast))
+        adapter.addCellGenerators(makeCellGenerators(for: Array(11...20)))
 
         // Tell adapter that we've changed generators
         adapter.forceRefill()
     }
 
-    /// Create cell generators
-    func makeCellGenerators() -> [CollectionCellGenerator] {
+    /// Create cells generators for range
+    func makeCellGenerators(for range: [Int]) -> [CollectionCellGenerator] {
         var generators = [CollectionCellGenerator]()
 
-        for index in 0...10 {
+        for index in 11...20 {
             let generator = TitleCollectionGenerator(model: "Cell: \(index)")
             generators.append(generator)
         }

--- a/Example/ReactiveDataDisplayManager/Table/DragAndDroppableTableViewController/DragAndDroppableTableViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Table/DragAndDroppableTableViewController/DragAndDroppableTableViewController.swift
@@ -13,7 +13,8 @@ final class DragAndDroppableTableViewController: UIViewController {
     // MARK: - Constants
 
     private enum Constants {
-        static let titleForSection = "Section"
+        static let titleForSectionFirst = "SectionFirst"
+        static let titleForSectionLast = "SectionLast"
     }
 
     // MARK: - IBOutlets
@@ -23,7 +24,7 @@ final class DragAndDroppableTableViewController: UIViewController {
     // MARK: - Private Properties
 
     private lazy var adapter = tableView.rddm.manualBuilder
-        .add(featurePlugin: .dragAndDroppable())
+        .add(featurePlugin: .dragAndDroppable(by: .all))
         .build()
 
     // MARK: - UIViewController
@@ -45,19 +46,21 @@ private extension DragAndDroppableTableViewController {
 
     /// This method is used to fill adapter
     func fillAdapter() {
-        // Add generator to adapter
-        adapter.addSectionHeaderGenerator(TitleHeaderGenerator(model: Constants.titleForSection))
-        adapter.addCellGenerators(makeCellGenerators())
+        // Add generators to adapter
+        adapter.addSectionHeaderGenerator(TitleHeaderGenerator(model: Constants.titleForSectionFirst))
+        adapter.addCellGenerators(makeCellGenerators(for: Array(1...10)))
+        adapter.addSectionHeaderGenerator(TitleHeaderGenerator(model: Constants.titleForSectionLast))
+        adapter.addCellGenerators(makeCellGenerators(for: Array(11...20)))
 
         // Tell adapter that we've changed generators
         adapter.forceRefill()
     }
 
-    // Create cells generators
-    func makeCellGenerators() -> [TableCellGenerator] {
+    /// Create cells generators for range
+    func makeCellGenerators(for range: [Int]) -> [TableCellGenerator] {
         var generators = [TableCellGenerator]()
 
-        for index in 0...10 {
+        for index in range {
             let generator = DragAndDroppableCellGenerator(with: "Cell: \(index)")
             generators.append(generator)
         }

--- a/Example/ReactiveDataDisplayManagerExample.xcodeproj/project.pbxproj
+++ b/Example/ReactiveDataDisplayManagerExample.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		0DD6E5FBEDB337CA8C5F8333 /* SwipeableTableGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB41F1ECB404261C7782A518 /* SwipeableTableGenerator.swift */; };
 		12E1CF0B4D16347A0EA11C4B /* ImageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7CF2AC0FF26C8FC1400F89D /* ImageCollectionViewCell.swift */; };
 		1C3876501C7423CBBEEBF123 /* ImageTableGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0371CFDF2AE2933334F5FEF1 /* ImageTableGenerator.swift */; };
+		1E688FAC228BF247ED0492FA /* Pods_ReactiveDataDisplayManagerExample_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BD9283009F28C328EC3161B /* Pods_ReactiveDataDisplayManagerExample_tvOS.framework */; };
 		204A35984295BD7510D838F0 /* TextStackCellGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FF511355AF2D02BFC43848 /* TextStackCellGenerator.swift */; };
 		24126DC79315B305A4FDACCE /* ImageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC4D0ADA4924AA2C98DC6EC /* ImageCollectionViewCell.swift */; };
 		24EC35DBCDEAD4C28FBE231B /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AC95B25E1801B34FD6AC5D1 /* Array.swift */; };
@@ -44,7 +45,7 @@
 		4A5B829E7FC4C8F1BD802EC6 /* TitleIconCollectionFooterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 793F94A30619B298E5BA9BAC /* TitleIconCollectionFooterView.xib */; };
 		4E9A3C4F7C1635C1786A0746 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EF76029E1252056740F057DF /* Assets.xcassets */; };
 		4EDCC2CE48EFA9A66BEA00C8 /* StackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB96FC58AF36480A2BA5E8F6 /* StackViewController.swift */; };
-		51E4780A0086E6BC219684B9 /* Pods_ReactiveDataDisplayManagerExample_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE26E502DA3699A3F940CDD5 /* Pods_ReactiveDataDisplayManagerExample_tvOS.framework */; };
+		50BFA9D60FC3B1D6DB5869F1 /* Pods_ReactiveDataDisplayManagerExample_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AEF75F09C393649475ED305C /* Pods_ReactiveDataDisplayManagerExample_iOS.framework */; };
 		56A8DF28B517E24E183769DA /* DragAndDroppableCellGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA2E4F7A7FFF1E5E6574E46 /* DragAndDroppableCellGenerator.swift */; };
 		5B659F369987AF1AB48FFA49 /* MainCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFBDB227714F3A62FDD9B78 /* MainCollectionViewController.swift */; };
 		5C275994C6E9A080C3E0DACE /* ImageCollectionCellGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EA8DD2FF5F7ABC2416F3C2C /* ImageCollectionCellGenerator.swift */; };
@@ -99,7 +100,6 @@
 		C0B28DF3926934F5488ABCDF /* ImageCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 126AA75B7E8B875CA17B1ADE /* ImageCollectionViewCell.xib */; };
 		C15D684439AADF9C7B8B4FD3 /* SectionTitleTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA165FA4831CE4BD0A3FBA0 /* SectionTitleTableViewController.swift */; };
 		C17628304B75FF43379E8C39 /* DiffableCollectionCellGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF1A84D42128FD0ACCDBA186 /* DiffableCollectionCellGenerator.swift */; };
-		C4C26DB44FF1C1EC30194D72 /* Pods_ReactiveDataDisplayManagerExample_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00255C6A9D2F9D4DD5F0D8DB /* Pods_ReactiveDataDisplayManagerExample_iOS.framework */; };
 		C650B35C1EA412E1FF8B986D /* PrefetchingCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83356740D148F762F89EBC9D /* PrefetchingCollectionViewController.swift */; };
 		C95CD4639477D654199A1ED2 /* SwipeActionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E34FCC6064184A97314D0ED /* SwipeActionProvider.swift */; };
 		CCA167B22F78BC5184B84B50 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29DE51C2AF8DE10CA9F92E7 /* String.swift */; };
@@ -128,9 +128,9 @@
 
 /* Begin PBXFileReference section */
 		001BB16BE2E141F75B940D27 /* UIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
-		00255C6A9D2F9D4DD5F0D8DB /* Pods_ReactiveDataDisplayManagerExample_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReactiveDataDisplayManagerExample_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		01118988EE30FADBF3525B0A /* ManualTableManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualTableManager.swift; sourceTree = "<group>"; };
 		0165D86C242386A8EEA77F48 /* FoldableCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldableCollectionViewCell.swift; sourceTree = "<group>"; };
+		01EB843B87C7B3682B3CE4CD /* Pods-ReactiveDataDisplayManagerExample_tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactiveDataDisplayManagerExample_tvOS.release.xcconfig"; path = "Target Support Files/Pods-ReactiveDataDisplayManagerExample_tvOS/Pods-ReactiveDataDisplayManagerExample_tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		03696B6C26DF276EA2CBF62D /* TitleCollectionHeaderGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleCollectionHeaderGenerator.swift; sourceTree = "<group>"; };
 		0371CFDF2AE2933334F5FEF1 /* ImageTableGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTableGenerator.swift; sourceTree = "<group>"; };
 		0D4602C83A0BFE6840DF362D /* MovableCollectionCellGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovableCollectionCellGenerator.swift; sourceTree = "<group>"; };
@@ -166,6 +166,7 @@
 		578291B4307978AAFAC20143 /* Pallete.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pallete.swift; sourceTree = "<group>"; };
 		57CCE75E305EDAEF36B2F98C /* TitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleTableViewCell.swift; sourceTree = "<group>"; };
 		58B9B7A39699D5FCDA60B310 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		5BD9283009F28C328EC3161B /* Pods_ReactiveDataDisplayManagerExample_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReactiveDataDisplayManagerExample_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5DA165FA4831CE4BD0A3FBA0 /* SectionTitleTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionTitleTableViewController.swift; sourceTree = "<group>"; };
 		5DB6E41047389B515852F284 /* DragAndDroppableCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragAndDroppableCollectionViewController.swift; sourceTree = "<group>"; };
 		5EA8DD2FF5F7ABC2416F3C2C /* ImageCollectionCellGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCollectionCellGenerator.swift; sourceTree = "<group>"; };
@@ -176,7 +177,6 @@
 		6BFBDB227714F3A62FDD9B78 /* MainCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCollectionViewController.swift; sourceTree = "<group>"; };
 		6C6FC596110A83223FA25408 /* ItemTitleCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemTitleCollectionViewController.swift; sourceTree = "<group>"; };
 		6DCA52FFA92CFC3829BB8E54 /* TitleWithIconTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleWithIconTableViewCell.swift; sourceTree = "<group>"; };
-		6E9BE20B1FE885F410B287D6 /* Pods-ReactiveDataDisplayManagerExample_tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactiveDataDisplayManagerExample_tvOS.debug.xcconfig"; path = "Target Support Files/Pods-ReactiveDataDisplayManagerExample_tvOS/Pods-ReactiveDataDisplayManagerExample_tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		6EF4B6D7D72C85C6E32BA669 /* SwipeableTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableTableViewController.swift; sourceTree = "<group>"; };
 		6F93E77221299A239B51BF7F /* TitleStackCellGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleStackCellGenerator.swift; sourceTree = "<group>"; };
 		70DCA90700277195993FA2B8 /* DifferenceTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DifferenceTableViewController.swift; sourceTree = "<group>"; };
@@ -191,27 +191,27 @@
 		7FDB067EB8AFDC23E5013FD6 /* AlphabeticalTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlphabeticalTableViewController.swift; sourceTree = "<group>"; };
 		822BCF3694F34717804DCF88 /* Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Appearance.swift; sourceTree = "<group>"; };
 		83356740D148F762F89EBC9D /* PrefetchingCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefetchingCollectionViewController.swift; sourceTree = "<group>"; };
-		84CB516F0DF7582D9570CBAD /* Pods-ReactiveDataDisplayManagerExample_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactiveDataDisplayManagerExample_iOS.debug.xcconfig"; path = "Target Support Files/Pods-ReactiveDataDisplayManagerExample_iOS/Pods-ReactiveDataDisplayManagerExample_iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		8E284CEC0582666D927EC02D /* SwipeableCollectionListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableCollectionListViewController.swift; sourceTree = "<group>"; };
 		8EFB49700A08E9D7CB895637 /* TitleWithIconTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleWithIconTableViewCell.xib; sourceTree = "<group>"; };
 		91ADF925ADE9443E1E2BAFB6 /* DifferenceCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DifferenceCollectionViewController.swift; sourceTree = "<group>"; };
 		9392223ADE0DD07181CF5C7B /* TitleCollectionReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleCollectionReusableView.swift; sourceTree = "<group>"; };
 		95A57F0E5014AAE731E5E509 /* MainGalleryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainGalleryController.swift; sourceTree = "<group>"; };
 		96946BCC833AEBED71BDA634 /* HeaderCollectionListView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HeaderCollectionListView.xib; sourceTree = "<group>"; };
+		9924D6D5292DE95CD83029C6 /* Pods-ReactiveDataDisplayManagerExample_tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactiveDataDisplayManagerExample_tvOS.debug.xcconfig"; path = "Target Support Files/Pods-ReactiveDataDisplayManagerExample_tvOS/Pods-ReactiveDataDisplayManagerExample_tvOS.debug.xcconfig"; sourceTree = "<group>"; };
+		99DB148F69438006B3543032 /* Pods-ReactiveDataDisplayManagerExample_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactiveDataDisplayManagerExample_iOS.debug.xcconfig"; path = "Target Support Files/Pods-ReactiveDataDisplayManagerExample_iOS/Pods-ReactiveDataDisplayManagerExample_iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		9AAF4EC7F8199FE77561B93C /* VerticalSizableTextGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalSizableTextGenerator.swift; sourceTree = "<group>"; };
 		9FE54BA279EBA492D3F36FD3 /* HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
 		A01825DE6F3160BA0ACD25D8 /* UnrollCellStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnrollCellStackView.swift; sourceTree = "<group>"; };
 		A43827BAA20A9EF3B05A721E /* GravityCellGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GravityCellGenerator.swift; sourceTree = "<group>"; };
 		A8C18F63930316A8468B041C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AB41F1ECB404261C7782A518 /* SwipeableTableGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableTableGenerator.swift; sourceTree = "<group>"; };
-		AB612B69266A834C73906EB6 /* Pods-ReactiveDataDisplayManagerExample_tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactiveDataDisplayManagerExample_tvOS.release.xcconfig"; path = "Target Support Files/Pods-ReactiveDataDisplayManagerExample_tvOS/Pods-ReactiveDataDisplayManagerExample_tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		ABD08177388A637B66A066E9 /* TitleCollectionReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleCollectionReusableView.swift; sourceTree = "<group>"; };
 		AC08D44C38A05E330FA79736 /* BaseCollectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCollectionManager.swift; sourceTree = "<group>"; };
 		AE45BE9D4ABBD950EDC6E2FB /* Localizable.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
+		AEF75F09C393649475ED305C /* Pods_ReactiveDataDisplayManagerExample_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReactiveDataDisplayManagerExample_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF1A84D42128FD0ACCDBA186 /* DiffableCollectionCellGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableCollectionCellGenerator.swift; sourceTree = "<group>"; };
 		B2E2B7EB4EDCFACD4A6A954C /* PaginatableCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatableCollectionViewController.swift; sourceTree = "<group>"; };
 		B48466610D1C8EBA481BA850 /* FoldableCollectionCellGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldableCollectionCellGenerator.swift; sourceTree = "<group>"; };
-		B711A1DCD41558E47B1EF343 /* Pods-ReactiveDataDisplayManagerExample_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactiveDataDisplayManagerExample_iOS.release.xcconfig"; path = "Target Support Files/Pods-ReactiveDataDisplayManagerExample_iOS/Pods-ReactiveDataDisplayManagerExample_iOS.release.xcconfig"; sourceTree = "<group>"; };
 		B7918691F21748932FFEEF6D /* InnerStackCellGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InnerStackCellGenerator.swift; sourceTree = "<group>"; };
 		B89F2E62537ECB80F91F812A /* HeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HeaderView.xib; sourceTree = "<group>"; };
 		B9FF511355AF2D02BFC43848 /* TextStackCellGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStackCellGenerator.swift; sourceTree = "<group>"; };
@@ -233,7 +233,6 @@
 		D380CEFE1B42A3046D14FF71 /* SectionTitleHeaderGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionTitleHeaderGenerator.swift; sourceTree = "<group>"; };
 		D8F1DF239F06EFD759988EF8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		DB379EA79E87D813B9E05535 /* TitleCollectionListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleCollectionListCell.xib; sourceTree = "<group>"; };
-		DE26E502DA3699A3F940CDD5 /* Pods_ReactiveDataDisplayManagerExample_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ReactiveDataDisplayManagerExample_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DEC665C492465DE0ACA510D0 /* TitleCollectionReusableView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleCollectionReusableView.xib; sourceTree = "<group>"; };
 		DF9DFCE12A61DE93236E881E /* TitleHeaderGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleHeaderGenerator.swift; sourceTree = "<group>"; };
 		DFFDDAD2FBE692DD04B2F3B9 /* ImageCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ImageCollectionViewCell.xib; sourceTree = "<group>"; };
@@ -251,6 +250,7 @@
 		F958FD39ACAA9A0CC09BC7D0 /* CollectionListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionListViewController.swift; sourceTree = "<group>"; };
 		FC1DAD5AD994C42F50E514EE /* TitleIconCollectionFooterGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleIconCollectionFooterGenerator.swift; sourceTree = "<group>"; };
 		FF080E64B9D36E8CE75064A7 /* UIViewController+Delay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Delay.swift"; sourceTree = "<group>"; };
+		FF868E18F679A36C1607D321 /* Pods-ReactiveDataDisplayManagerExample_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ReactiveDataDisplayManagerExample_iOS.release.xcconfig"; path = "Target Support Files/Pods-ReactiveDataDisplayManagerExample_iOS/Pods-ReactiveDataDisplayManagerExample_iOS.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -259,7 +259,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F1679D6879E3F1B16047438B /* UIKit.framework in Frameworks */,
-				C4C26DB44FF1C1EC30194D72 /* Pods_ReactiveDataDisplayManagerExample_iOS.framework in Frameworks */,
+				50BFA9D60FC3B1D6DB5869F1 /* Pods_ReactiveDataDisplayManagerExample_iOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -268,7 +268,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0043FC0C2FFB75867BE031CC /* UIKit.framework in Frameworks */,
-				51E4780A0086E6BC219684B9 /* Pods_ReactiveDataDisplayManagerExample_tvOS.framework in Frameworks */,
+				1E688FAC228BF247ED0492FA /* Pods_ReactiveDataDisplayManagerExample_tvOS.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -333,13 +333,13 @@
 			path = CollectionCompositionalViewController;
 			sourceTree = "<group>";
 		};
-		0D0DD038824780565E3F6BCA /* Pods */ = {
+		11D9DBE09E7A148D0E10E59D /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				84CB516F0DF7582D9570CBAD /* Pods-ReactiveDataDisplayManagerExample_iOS.debug.xcconfig */,
-				B711A1DCD41558E47B1EF343 /* Pods-ReactiveDataDisplayManagerExample_iOS.release.xcconfig */,
-				6E9BE20B1FE885F410B287D6 /* Pods-ReactiveDataDisplayManagerExample_tvOS.debug.xcconfig */,
-				AB612B69266A834C73906EB6 /* Pods-ReactiveDataDisplayManagerExample_tvOS.release.xcconfig */,
+				99DB148F69438006B3543032 /* Pods-ReactiveDataDisplayManagerExample_iOS.debug.xcconfig */,
+				FF868E18F679A36C1607D321 /* Pods-ReactiveDataDisplayManagerExample_iOS.release.xcconfig */,
+				9924D6D5292DE95CD83029C6 /* Pods-ReactiveDataDisplayManagerExample_tvOS.debug.xcconfig */,
+				01EB843B87C7B3682B3CE4CD /* Pods-ReactiveDataDisplayManagerExample_tvOS.release.xcconfig */,
 			);
 			name = Pods;
 			path = Pods;
@@ -412,8 +412,8 @@
 			isa = PBXGroup;
 			children = (
 				BC63B8F3540DB313A90623C7 /* UIKit.framework */,
-				00255C6A9D2F9D4DD5F0D8DB /* Pods_ReactiveDataDisplayManagerExample_iOS.framework */,
-				DE26E502DA3699A3F940CDD5 /* Pods_ReactiveDataDisplayManagerExample_tvOS.framework */,
+				AEF75F09C393649475ED305C /* Pods_ReactiveDataDisplayManagerExample_iOS.framework */,
+				5BD9283009F28C328EC3161B /* Pods_ReactiveDataDisplayManagerExample_tvOS.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -788,7 +788,7 @@
 				02BF68695BF245EEE6443FE1 /* ReactiveDataDisplayManagerExampleTv */,
 				299303BB717880B5A2E66198 /* Frameworks */,
 				BF88590C60E62AD28FD1806F /* Products */,
-				0D0DD038824780565E3F6BCA /* Pods */,
+				11D9DBE09E7A148D0E10E59D /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1053,11 +1053,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 792A0C5AA660FAC0E7B00B3D /* Build configuration list for PBXNativeTarget "ReactiveDataDisplayManagerExample_iOS" */;
 			buildPhases = (
-				AE94B8D322CDC804765E27C0 /* [CP] Check Pods Manifest.lock */,
+				F45DDA7A21EBC20C16F07857 /* [CP] Check Pods Manifest.lock */,
 				ECA6C933031CC97E27A086F3 /* Sources */,
 				AE0B9C82ADAB32EEEB8C37B5 /* Resources */,
 				6E0370DC08D4858FC00F5C4C /* Frameworks */,
-				068CF1666DA7E489F97CF4C3 /* [CP] Embed Pods Frameworks */,
+				096F3832B6FA3CFF4CDCFD38 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1072,11 +1072,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1C4D28686287CFD39C2A5A0A /* Build configuration list for PBXNativeTarget "ReactiveDataDisplayManagerExample_tvOS" */;
 			buildPhases = (
-				0E212B3F755C3D4C9E9BE6B4 /* [CP] Check Pods Manifest.lock */,
+				A3287E1C86346C367FC9A4EE /* [CP] Check Pods Manifest.lock */,
 				C6A76767FEF83A6D18703384 /* Sources */,
 				4A85B19C4D98CA260927AC9C /* Resources */,
 				8FB3595164174D4BE70C5C0F /* Frameworks */,
-				E80AB8626F9493BB2059FB27 /* [CP] Embed Pods Frameworks */,
+				1A82A337E45C1AD5D61B4916 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1164,7 +1164,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		068CF1666DA7E489F97CF4C3 /* [CP] Embed Pods Frameworks */ = {
+		096F3832B6FA3CFF4CDCFD38 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1181,7 +1181,24 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ReactiveDataDisplayManagerExample_iOS/Pods-ReactiveDataDisplayManagerExample_iOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		0E212B3F755C3D4C9E9BE6B4 /* [CP] Check Pods Manifest.lock */ = {
+		1A82A337E45C1AD5D61B4916 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ReactiveDataDisplayManagerExample_tvOS/Pods-ReactiveDataDisplayManagerExample_tvOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ReactiveDataDisplayManagerExample_tvOS/Pods-ReactiveDataDisplayManagerExample_tvOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ReactiveDataDisplayManagerExample_tvOS/Pods-ReactiveDataDisplayManagerExample_tvOS-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A3287E1C86346C367FC9A4EE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1203,7 +1220,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		AE94B8D322CDC804765E27C0 /* [CP] Check Pods Manifest.lock */ = {
+		F45DDA7A21EBC20C16F07857 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1223,23 +1240,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E80AB8626F9493BB2059FB27 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ReactiveDataDisplayManagerExample_tvOS/Pods-ReactiveDataDisplayManagerExample_tvOS-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ReactiveDataDisplayManagerExample_tvOS/Pods-ReactiveDataDisplayManagerExample_tvOS-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ReactiveDataDisplayManagerExample_tvOS/Pods-ReactiveDataDisplayManagerExample_tvOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -1366,7 +1366,7 @@
 /* Begin XCBuildConfiguration section */
 		01EDD065C9F1601F67B2C661 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AB612B69266A834C73906EB6 /* Pods-ReactiveDataDisplayManagerExample_tvOS.release.xcconfig */;
+			baseConfigurationReference = 01EB843B87C7B3682B3CE4CD /* Pods-ReactiveDataDisplayManagerExample_tvOS.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -1508,7 +1508,7 @@
 		};
 		91648FFF59AB6577C8088B89 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B711A1DCD41558E47B1EF343 /* Pods-ReactiveDataDisplayManagerExample_iOS.release.xcconfig */;
+			baseConfigurationReference = FF868E18F679A36C1607D321 /* Pods-ReactiveDataDisplayManagerExample_iOS.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1532,7 +1532,7 @@
 		};
 		DD4B9461B99B0EF96DBB4346 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 84CB516F0DF7582D9570CBAD /* Pods-ReactiveDataDisplayManagerExample_iOS.debug.xcconfig */;
+			baseConfigurationReference = 99DB148F69438006B3543032 /* Pods-ReactiveDataDisplayManagerExample_iOS.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1556,7 +1556,7 @@
 		};
 		FC5EC75D69FD9FC6C2940499 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6E9BE20B1FE885F410B287D6 /* Pods-ReactiveDataDisplayManagerExample_tvOS.debug.xcconfig */;
+			baseConfigurationReference = 9924D6D5292DE95CD83029C6 /* Pods-ReactiveDataDisplayManagerExample_tvOS.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;

--- a/ReactiveDataDisplayManager.xcodeproj/project.pbxproj
+++ b/ReactiveDataDisplayManager.xcodeproj/project.pbxproj
@@ -199,8 +199,8 @@
 		A0D6BA1CBC31E3DB487AF822 /* TableMovable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59BD3E3C00425163B8A3DDC0 /* TableMovable.swift */; };
 		A1A62C49AB2E26DF31EBFA66 /* SizableCollectionCellGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8C175D2A03DC50EEBA23F9 /* SizableCollectionCellGenerator.swift */; };
 		A36E96F430B818303587616B /* Configurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE452F1BC75AD3E975C5C935 /* Configurable.swift */; };
-		A4D7DB2A273E382900F8DBBD /* Sections.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D7DB29273E382900F8DBBD /* Sections.swift */; };
-		A4D7DB2B273E382900F8DBBD /* Sections.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D7DB29273E382900F8DBBD /* Sections.swift */; };
+		A49840EE273EF06200805B44 /* DropStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49840ED273EF06200805B44 /* DropStrategy.swift */; };
+		A49840EF273EF06200805B44 /* DropStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49840ED273EF06200805B44 /* DropStrategy.swift */; };
 		A61561F1A321DF80212AB923 /* BaseStackDataDisplatManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A823B265B4A6141BCD38940 /* BaseStackDataDisplatManagerTests.swift */; };
 		A7DE5D5EBE41F318FE41FA78 /* ConfigurableItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC8419F5D33C0C4FDEF350F /* ConfigurableItem.swift */; };
 		A8609534FD8C1C56EB288857 /* EmptyGravityTableHeaderGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E7A3AF9B24D4A46012EC1E /* EmptyGravityTableHeaderGenerator.swift */; };
@@ -465,7 +465,7 @@
 		A037D620404F94F7C983D428 /* SwipeActionsConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeActionsConfigurable.swift; sourceTree = "<group>"; };
 		A2792DD250BD0AD76291D0DE /* BaseCollectionDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCollectionDataSource.swift; sourceTree = "<group>"; };
 		A3C6EACAA6CEAC3E52EF7D28 /* ManualTableManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualTableManager.swift; sourceTree = "<group>"; };
-		A4D7DB29273E382900F8DBBD /* Sections.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sections.swift; sourceTree = "<group>"; };
+		A49840ED273EF06200805B44 /* DropStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DropStrategy.swift; sourceTree = "<group>"; };
 		A6240F096FE4C04570FA9FDC /* PrefetchEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefetchEvent.swift; sourceTree = "<group>"; };
 		A6A1C839D6624A199C3EFD36 /* TableSwipeActionsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableSwipeActionsConfiguration.swift; sourceTree = "<group>"; };
 		A955504B2B31B7C47938B703 /* SizableCollectionDataDisplayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizableCollectionDataDisplayManager.swift; sourceTree = "<group>"; };
@@ -958,7 +958,7 @@
 				43D5BCBCD54DA859D79F464A /* DraggablePluginDelegate.swift */,
 				490A89B02B42F053C9D38B34 /* DropCoordinatorWrapper.swift */,
 				92BBA76DBFD19AC79B518BD4 /* DroppablePluginDelegate.swift */,
-				A4D7DB29273E382900F8DBBD /* Sections.swift */,
+				A49840ED273EF06200805B44 /* DropStrategy.swift */,
 			);
 			path = DragAndDroppablePlugin;
 			sourceTree = "<group>";
@@ -1378,9 +1378,9 @@
 				F0C1C837FBAACD6A1F2554C8 /* TablePrefetchProxyPlugin.swift in Sources */,
 				EB4D3C58A8F37CA2C77113B0 /* TablePrefetcherablePlugin.swift in Sources */,
 				F6E6DBB7309B6A422BCA959D /* TableRefreshablePlugin.swift in Sources */,
-				A4D7DB2A273E382900F8DBBD /* Sections.swift in Sources */,
 				23542D02DE6B28732BDBECCE /* TableScrollViewDelegateProxyPlugin.swift in Sources */,
 				C409F574B60FF889FF140640 /* TableSectionTitleDisplayable.swift in Sources */,
+				A49840EE273EF06200805B44 /* DropStrategy.swift in Sources */,
 				5729E7136DBDB4CF1F9217B3 /* TableSectionTitleDisplayablePlugin.swift in Sources */,
 				7088AC8E3991F96D84DE3316 /* TableSectionTitleWrapper.swift in Sources */,
 				3E33B66E2044D85293BA37D6 /* TableSelectablePlugin.swift in Sources */,
@@ -1546,9 +1546,9 @@
 				14286A4E4D9D7F891CB643D7 /* TablePrefetchProxyPlugin.swift in Sources */,
 				365F70790BE03F83AD7C8B30 /* TablePrefetcherablePlugin.swift in Sources */,
 				699F357E031DC52CFC3753F8 /* TableRefreshablePlugin.swift in Sources */,
-				A4D7DB2B273E382900F8DBBD /* Sections.swift in Sources */,
 				395FC4E484548A4F1D416814 /* TableScrollViewDelegateProxyPlugin.swift in Sources */,
 				6BBCB1E4DBB476FB2C427DFD /* TableSectionTitleDisplayable.swift in Sources */,
+				A49840EF273EF06200805B44 /* DropStrategy.swift in Sources */,
 				AC463FD260D5303138D0483E /* TableSectionTitleDisplayablePlugin.swift in Sources */,
 				8D114643B0FF5C98742E0E68 /* TableSectionTitleWrapper.swift in Sources */,
 				00E3116A950942E8F81AE6F3 /* TableSelectablePlugin.swift in Sources */,

--- a/ReactiveDataDisplayManager.xcodeproj/project.pbxproj
+++ b/ReactiveDataDisplayManager.xcodeproj/project.pbxproj
@@ -199,6 +199,8 @@
 		A0D6BA1CBC31E3DB487AF822 /* TableMovable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59BD3E3C00425163B8A3DDC0 /* TableMovable.swift */; };
 		A1A62C49AB2E26DF31EBFA66 /* SizableCollectionCellGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8C175D2A03DC50EEBA23F9 /* SizableCollectionCellGenerator.swift */; };
 		A36E96F430B818303587616B /* Configurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE452F1BC75AD3E975C5C935 /* Configurable.swift */; };
+		A4D7DB2A273E382900F8DBBD /* Sections.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D7DB29273E382900F8DBBD /* Sections.swift */; };
+		A4D7DB2B273E382900F8DBBD /* Sections.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4D7DB29273E382900F8DBBD /* Sections.swift */; };
 		A61561F1A321DF80212AB923 /* BaseStackDataDisplatManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A823B265B4A6141BCD38940 /* BaseStackDataDisplatManagerTests.swift */; };
 		A7DE5D5EBE41F318FE41FA78 /* ConfigurableItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BC8419F5D33C0C4FDEF350F /* ConfigurableItem.swift */; };
 		A8609534FD8C1C56EB288857 /* EmptyGravityTableHeaderGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E7A3AF9B24D4A46012EC1E /* EmptyGravityTableHeaderGenerator.swift */; };
@@ -463,6 +465,7 @@
 		A037D620404F94F7C983D428 /* SwipeActionsConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeActionsConfigurable.swift; sourceTree = "<group>"; };
 		A2792DD250BD0AD76291D0DE /* BaseCollectionDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCollectionDataSource.swift; sourceTree = "<group>"; };
 		A3C6EACAA6CEAC3E52EF7D28 /* ManualTableManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualTableManager.swift; sourceTree = "<group>"; };
+		A4D7DB29273E382900F8DBBD /* Sections.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sections.swift; sourceTree = "<group>"; };
 		A6240F096FE4C04570FA9FDC /* PrefetchEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrefetchEvent.swift; sourceTree = "<group>"; };
 		A6A1C839D6624A199C3EFD36 /* TableSwipeActionsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableSwipeActionsConfiguration.swift; sourceTree = "<group>"; };
 		A955504B2B31B7C47938B703 /* SizableCollectionDataDisplayManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizableCollectionDataDisplayManager.swift; sourceTree = "<group>"; };
@@ -578,14 +581,6 @@
 				407757CF950AF07BCA983885 /* FlowCollectionDelegate.swift */,
 			);
 			path = Delegate;
-			sourceTree = "<group>";
-		};
-		032CFE2A4BAA81D77BD0B945 /* REFACTORING */ = {
-			isa = PBXGroup;
-			children = (
-				A9CCFE74D85E93281C7B0A86 /* Protocols */,
-			);
-			path = REFACTORING;
 			sourceTree = "<group>";
 		};
 		061609D764C2E840E7C6D3AD /* Manager */ = {
@@ -752,22 +747,6 @@
 			path = Collection;
 			sourceTree = "<group>";
 		};
-		5E4DED0C836B95D4A2AA71EC /* PluginAction */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = PluginAction;
-			sourceTree = "<group>";
-		};
-		5E5EEDC3878570795A67EE56 /* Plugins */ = {
-			isa = PBXGroup;
-			children = (
-				6651920D5F1134A32A74F1AB /* Generators */,
-				5E4DED0C836B95D4A2AA71EC /* PluginAction */,
-			);
-			path = Plugins;
-			sourceTree = "<group>";
-		};
 		5FC8B05F432A1CBF451577AD /* Modifier */ = {
 			isa = PBXGroup;
 			children = (
@@ -790,13 +769,6 @@
 				BC4327BAC235A817BDDB8C2D /* XCTestCase+FatalError.swift */,
 			);
 			path = ReactiveDataDisplayManagerTests;
-			sourceTree = "<group>";
-		};
-		6651920D5F1134A32A74F1AB /* Generators */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Generators;
 			sourceTree = "<group>";
 		};
 		693D5446F63554917C2E99C7 /* Deprecated */ = {
@@ -839,7 +811,6 @@
 				541729A882381B290F04154F /* Collection */,
 				836365E89537F3A370FF42BC /* Models */,
 				4F976C89B581915E384D0A8E /* Protocols */,
-				032CFE2A4BAA81D77BD0B945 /* REFACTORING */,
 				CE78A64118953BB0F6A0CCFF /* Stack */,
 				AAC1F935B1C67CFABBE7753E /* Table */,
 				B53C25BB527110DC62F44CDF /* Utils */,
@@ -946,14 +917,6 @@
 			path = Delegate;
 			sourceTree = "<group>";
 		};
-		A9CCFE74D85E93281C7B0A86 /* Protocols */ = {
-			isa = PBXGroup;
-			children = (
-				5E5EEDC3878570795A67EE56 /* Plugins */,
-			);
-			path = Protocols;
-			sourceTree = "<group>";
-		};
 		AAC1F935B1C67CFABBE7753E /* Table */ = {
 			isa = PBXGroup;
 			children = (
@@ -995,6 +958,7 @@
 				43D5BCBCD54DA859D79F464A /* DraggablePluginDelegate.swift */,
 				490A89B02B42F053C9D38B34 /* DropCoordinatorWrapper.swift */,
 				92BBA76DBFD19AC79B518BD4 /* DroppablePluginDelegate.swift */,
+				A4D7DB29273E382900F8DBBD /* Sections.swift */,
 			);
 			path = DragAndDroppablePlugin;
 			sourceTree = "<group>";
@@ -1414,6 +1378,7 @@
 				F0C1C837FBAACD6A1F2554C8 /* TablePrefetchProxyPlugin.swift in Sources */,
 				EB4D3C58A8F37CA2C77113B0 /* TablePrefetcherablePlugin.swift in Sources */,
 				F6E6DBB7309B6A422BCA959D /* TableRefreshablePlugin.swift in Sources */,
+				A4D7DB2A273E382900F8DBBD /* Sections.swift in Sources */,
 				23542D02DE6B28732BDBECCE /* TableScrollViewDelegateProxyPlugin.swift in Sources */,
 				C409F574B60FF889FF140640 /* TableSectionTitleDisplayable.swift in Sources */,
 				5729E7136DBDB4CF1F9217B3 /* TableSectionTitleDisplayablePlugin.swift in Sources */,
@@ -1581,6 +1546,7 @@
 				14286A4E4D9D7F891CB643D7 /* TablePrefetchProxyPlugin.swift in Sources */,
 				365F70790BE03F83AD7C8B30 /* TablePrefetcherablePlugin.swift in Sources */,
 				699F357E031DC52CFC3753F8 /* TableRefreshablePlugin.swift in Sources */,
+				A4D7DB2B273E382900F8DBBD /* Sections.swift in Sources */,
 				395FC4E484548A4F1D416814 /* TableScrollViewDelegateProxyPlugin.swift in Sources */,
 				6BBCB1E4DBB476FB2C427DFD /* TableSectionTitleDisplayable.swift in Sources */,
 				AC463FD260D5303138D0483E /* TableSectionTitleDisplayablePlugin.swift in Sources */,
@@ -1638,7 +1604,11 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MARKETING_VERSION = 7.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ru.surfstudio.rddm;
 				PRODUCT_NAME = ReactiveDataDisplayManager;
@@ -1736,7 +1706,11 @@
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MARKETING_VERSION = 7.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ru.surfstudio.rddm;
 				PRODUCT_NAME = ReactiveDataDisplayManager;
@@ -1778,7 +1752,11 @@
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MARKETING_VERSION = 7.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ru.surfstudio.rddm;
 				PRODUCT_NAME = ReactiveDataDisplayManager;
@@ -1881,7 +1859,11 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MARKETING_VERSION = 7.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = ru.surfstudio.rddm;
 				PRODUCT_NAME = ReactiveDataDisplayManager;

--- a/Source/Protocols/Plugins/FeaturePlugin/DragAndDroppablePlugin/DragAndDroppablePlugin.swift
+++ b/Source/Protocols/Plugins/FeaturePlugin/DragAndDroppablePlugin/DragAndDroppablePlugin.swift
@@ -24,6 +24,12 @@ open class TableDragAndDroppablePlugin: TableFeaturePlugin, DragAndDroppable {
     open var draggableDelegate = DraggablePluginDelegate<Provider>()
     open var droppableDelegate = DroppablePluginDelegate<Provider, UITableViewDropCoordinator>()
 
+    // MARK: - Initializations
+
+    init(dropStrategy: StrategyDropable) {
+        droppableDelegate.dropStrategy = dropStrategy
+    }
+
 }
 
 // MARK: - Public init
@@ -32,10 +38,12 @@ public extension TableFeaturePlugin {
 
     /// Plugin to drag and drop cells
     ///
-    /// Allow dragging and dropping cells builded with `DragAndDroppableItemSource` generators
+    /// Allow dragging and dropping cells builded with `DragAndDroppableItemSource` generators by section
+    /// - parameters:
+    ///     - sections: allow dropping across sections (all or current)
     @available(iOS 11.0, *)
-    static func dragAndDroppable() -> TableDragAndDroppablePlugin {
-        .init()
+    static func dragAndDroppable(by sections: DropStrategy = .all) -> TableDragAndDroppablePlugin {
+        .init(dropStrategy: sections)
     }
 
 }
@@ -55,16 +63,24 @@ open class CollectionDragAndDroppablePlugin: CollectionFeaturePlugin, DragAndDro
     open var draggableDelegate = DraggablePluginDelegate<Provider>()
     open var droppableDelegate = DroppablePluginDelegate<Provider, UICollectionViewDropCoordinator>()
 
+    // MARK: - Initializations
+
+    init(dropStrategy: StrategyDropable) {
+        droppableDelegate.dropStrategy = dropStrategy
+    }
+
 }
 
 public extension CollectionFeaturePlugin {
 
     /// Plugin to drag and drop cells
     ///
-    /// Allow dragging and dropping cells builded with `DragAndDroppableItemSource` generators
+    /// Allow dragging and dropping cells builded with `DragAndDroppableItemSource` generators by section
+    /// - parameters:
+    ///     - sections: allow dropping across sections (all or current)
     @available(iOS 11.0, *)
-    static func dragAndDroppable() -> CollectionDragAndDroppablePlugin {
-        .init()
+    static func dragAndDroppable(by sections: DropStrategy = .all) -> CollectionDragAndDroppablePlugin {
+        .init(dropStrategy: sections)
     }
 
 }

--- a/Source/Protocols/Plugins/FeaturePlugin/DragAndDroppablePlugin/DropStrategy.swift
+++ b/Source/Protocols/Plugins/FeaturePlugin/DragAndDroppablePlugin/DropStrategy.swift
@@ -1,0 +1,36 @@
+//
+//  SectionsType.swift
+//  Pods
+//
+//  Created by Konstantin Porokhov on 11.11.2021.
+//
+
+import Foundation
+
+/// Allow dragging cells according to strategy
+protocol StrategyDropable {
+    /// The method defines the strategy for the drag and drop behavior.
+    /// - parameters:
+    ///     - source:  Source IndexPath
+    ///     - destination: Destination IndexPath
+    /// - returns: Returns a Bool value
+    func canDrop(from source: IndexPath, to destination: IndexPath) -> Bool
+}
+
+public enum DropStrategy: StrategyDropable {
+
+    /// Allow drop item from any to any
+    case all
+    /// Allow drop item only inside current section
+    case current
+
+    /// The method defines the strategy for the drag and drop behavior.
+    /// - Returns: true if - case all;  - case current and source.section equal destination.section
+    func canDrop(from source: IndexPath, to destination: IndexPath) -> Bool {
+        switch self {
+        case .all: return true
+        case .current: return source.section == destination.section
+        }
+    }
+
+}

--- a/Source/Protocols/Plugins/FeaturePlugin/DragAndDroppablePlugin/DroppablePluginDelegate.swift
+++ b/Source/Protocols/Plugins/FeaturePlugin/DragAndDroppablePlugin/DroppablePluginDelegate.swift
@@ -21,6 +21,10 @@ open class DroppablePluginDelegate<Provider: GeneratorsProvider, CoordinatorType
     public typealias Coordinator = DropCoordinatorWrapper<CoordinatorType>
     public typealias GeneratorType = DragAndDroppableItemSource
 
+    // MARK: - Internal Properties
+
+    var dropStrategy: StrategyDropable?
+
 }
 
 // MARK: - DroppableDelegate
@@ -90,7 +94,8 @@ private extension DroppablePluginDelegate {
             guard
                 let sourceIndexPath = $0.sourceIndexPath,
                 destinationIndexPath != sourceIndexPath,
-                let itemToMove = provider?.generators[safe: sourceIndexPath.section]?[safe: sourceIndexPath.row]
+                let itemToMove = provider?.generators[safe: sourceIndexPath.section]?[safe: sourceIndexPath.row],
+                dropStrategy?.canDrop(from: sourceIndexPath, to: destinationIndexPath) ?? true
             else { return }
 
             animator?.perform(in: view, animated: true, operation: { [weak provider, modifier] in


### PR DESCRIPTION
## Что сделано?

- Добавил enum Sections с выбором секций для работы dragAndDrop в Plugins/FeaturePlugin/DragAndDroppablePlugin
- Добавил enum в метод dragAndDroppable
- Добавил стратегии ограничении дропа в DroppablePluginDelegate

## Зачем это сделано?

- Бывает так что на проекте не всегда требуется перемещение ячеек в другую секцию, поэтому мы сделали выбор для перемещения - либо по текущей секции, либо по всем. По умолчанию перемещение ячеек доступно по всем секциям

## Как протестировать?

- Попробовать поменять конфигурацию при добавления плагина в адаптер
- Зайти в Example проект выбрать table/collection with drag'n'drop cell
- Перетаскиваем ячейку в свою/другую секцию
