### PR TITLE
[Дубликат] Добавление публичного инита для EmptyCollectionGenerators и исправление регистрации в коллекции

### DIFF
--- a/Source/Collection/Generators/EmptyCollectionFooterGenarator.swift
+++ b/Source/Collection/Generators/EmptyCollectionFooterGenarator.swift
@@ -8,19 +8,24 @@
 import UIKit
 
 public class EmptyCollectionFooterGenerator: CollectionFooterGenerator {
+
+    public let elementKind = UICollectionView.elementKindSectionFooter
+
     public func size(_ collectionView: UICollectionView, forSection section: Int) -> CGSize {
         return .zero
     }
 
     public func generate(collectionView: UICollectionView, for indexPath: IndexPath) -> UICollectionReusableView {
-        let header = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionFooter,
+        let header = collectionView.dequeueReusableSupplementaryView(ofKind: elementKind,
                                                                      withReuseIdentifier: self.identifier.nameOfClass,
                                                                      for: indexPath)
         return header
     }
 
     public func registerFooter(in collectionView: UICollectionView) {
-        collectionView.register(identifier, forCellWithReuseIdentifier: identifier.nameOfClass)
+        collectionView.register(identifier,
+                                forSupplementaryViewOfKind: elementKind,
+                                withReuseIdentifier: identifier.nameOfClass)
     }
 
     public var identifier: UICollectionReusableView.Type {

--- a/Source/Collection/Generators/EmptyCollectionHeaderGenerator.swift
+++ b/Source/Collection/Generators/EmptyCollectionHeaderGenerator.swift
@@ -11,20 +11,25 @@ import UIKit
 public class EmptyCollectionHeaderGenerator: CollectionHeaderGenerator {
 
     public let uuid = UUID().uuidString
+    public let elementKind = UICollectionView.elementKindSectionHeader
+
+    public init() { }
 
     public func size(_ collectionView: UICollectionView, forSection section: Int) -> CGSize {
         return .zero
     }
 
     public func generate(collectionView: UICollectionView, for indexPath: IndexPath) -> UICollectionReusableView {
-        let header = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader,
+        let header = collectionView.dequeueReusableSupplementaryView(ofKind: elementKind,
                                                                      withReuseIdentifier: self.identifier.nameOfClass,
                                                                      for: indexPath)
         return header
     }
 
     public func registerHeader(in collectionView: UICollectionView) {
-        collectionView.register(identifier, forCellWithReuseIdentifier: identifier.nameOfClass)
+        collectionView.register(identifier,
+                                forSupplementaryViewOfKind: elementKind,
+                                withReuseIdentifier: identifier.nameOfClass)
     }
 
     public var identifier: UICollectionReusableView.Type {


### PR DESCRIPTION
- Дублирующий ПР на develop от #158

## Что сделано?

- Добавлен публичный инит.
- Исправлен метод регистрации в коллекции

## Зачем это сделано?

- Без публичного инита нельзя создать экзепляр класса
- Был использован неправильный метод регистрации SupplementaryView, в следствии чего происходил краш