### PR TITLE
Drag and Drop and Movable plugins tests

### DIFF
--- a/Example/ReactiveDataDisplayManager/Collection/DragAndDroppableCollectionViewController/DragAndDroppableCollectionViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Collection/DragAndDroppableCollectionViewController/DragAndDroppableCollectionViewController.swift
@@ -37,6 +37,7 @@ final class DragAndDroppableCollectionViewController: UIViewController {
         title = "Collection with drag'n'drop items"
 
         configureLayoutFlow()
+        collectionView.accessibilityIdentifier = "Collection_with_drag_n_drop_items"
         collectionView.dragInteractionEnabled = true
 
         fillAdapter()

--- a/Example/ReactiveDataDisplayManager/Collection/MovableCollectionViewController/MovableCollectionViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Collection/MovableCollectionViewController/MovableCollectionViewController.swift
@@ -61,6 +61,9 @@ private extension MovableCollectionViewController {
 
         let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongGesture(gesture:)))
         collectionView.addGestureRecognizer(longPressGesture)
+
+        collectionView.dragInteractionEnabled = false
+        collectionView.accessibilityIdentifier = "Collection_with_movable_cell"
     }
 
     /// This method is used to fill adapter

--- a/Example/ReactiveDataDisplayManager/Collection/Views/Cells/TitleCollectionListCell/TitleCollectionListCell.swift
+++ b/Example/ReactiveDataDisplayManager/Collection/Views/Cells/TitleCollectionListCell/TitleCollectionListCell.swift
@@ -20,6 +20,7 @@ class TitleCollectionListCell: UICollectionViewCell, ConfigurableItem {
     func configure(with title: String) {
         titleLabel.text = title
         backgroundColor = .lightGray
+        accessibilityLabel = title
     }
 
 }

--- a/Example/ReactiveDataDisplayManager/Collection/Views/Cells/TitleCollectionViewCell/TitleCollectionViewCell.swift
+++ b/Example/ReactiveDataDisplayManager/Collection/Views/Cells/TitleCollectionViewCell/TitleCollectionViewCell.swift
@@ -19,6 +19,7 @@ class TitleCollectionViewCell: UICollectionViewCell, ConfigurableItem {
 
     func configure(with title: String) {
         titleLabel.text = title
+        accessibilityLabel = title
     }
 
 }

--- a/Example/ReactiveDataDisplayManager/Table/DragAndDroppableTableViewController/DragAndDroppableTableViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Table/DragAndDroppableTableViewController/DragAndDroppableTableViewController.swift
@@ -33,6 +33,7 @@ final class DragAndDroppableTableViewController: UIViewController {
         super.viewDidLoad()
         title = "table with drag'n'drop cell"
 
+        tableView.accessibilityIdentifier = "Table_with_drag_n_drop_cell"
         tableView.dragInteractionEnabled = true
 
         fillAdapter()

--- a/Example/ReactiveDataDisplayManager/Table/MovableTableViewController/MovableTableViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Table/MovableTableViewController/MovableTableViewController.swift
@@ -15,7 +15,7 @@ final class MovableTableViewController: UIViewController {
 
     private enum Constants {
         static let titleForSection = "Section"
-        static let models = [String](repeating: "movable cell", count: 5)
+        static let models = Array(repeating: "movable cell", count: 5)
     }
 
     // MARK: - IBOutlets
@@ -33,6 +33,8 @@ final class MovableTableViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "table with movable cell"
+        tableView.accessibilityIdentifier = "Table_with_movable_cell"
+        tableView.dragInteractionEnabled = false
         fillAdapter()
     }
 
@@ -45,10 +47,10 @@ private extension MovableTableViewController {
     /// This method is used to fill adapter
     func fillAdapter() {
         // Add generator to adapter
-        adapter.addSectionHeaderGenerator(TitleHeaderGenerator(model: Constants.titleForSection))
-        adapter.addCellGenerators(makeMovableCellGenerators())
-        adapter.addSectionHeaderGenerator(TitleHeaderGenerator(model: Constants.titleForSection))
-        adapter.addCellGenerators(makeMovableCellGenerators())
+        adapter.addSectionHeaderGenerator(TitleHeaderGenerator(model: Constants.titleForSection + " 1"))
+        adapter.addCellGenerators(makeMovableCellGenerators(for: Array(1...5)))
+        adapter.addSectionHeaderGenerator(TitleHeaderGenerator(model: Constants.titleForSection + " 2"))
+        adapter.addCellGenerators(makeMovableCellGenerators(for: Array(1...5)))
 
         // Tell adapter that we've changed generators
         adapter.forceRefill()
@@ -56,8 +58,15 @@ private extension MovableTableViewController {
     }
 
     // Create cells generators
-    func makeMovableCellGenerators() -> [MovableCellGenerator] {
-        return Constants.models.map { MovableCellGenerator(with: $0) }
+    func makeMovableCellGenerators(for range: [Int]) -> [MovableCellGenerator] {
+        var generators = [MovableCellGenerator]()
+
+        for index in range {
+            let generator = MovableCellGenerator(with: "Cell: \(index)")
+            generators.append(generator)
+        }
+
+        return generators
     }
 
 }

--- a/Example/ReactiveDataDisplayManager/Table/Views/Cells/TitleTableViewCell/TitleTableViewCell.swift
+++ b/Example/ReactiveDataDisplayManager/Table/Views/Cells/TitleTableViewCell/TitleTableViewCell.swift
@@ -35,6 +35,7 @@ extension TitleTableViewCell: ConfigurableItem {
 
     func configure(with model: String) {
         titleLabel.text = model
+        accessibilityLabel = model
     }
 
 }

--- a/Example/ReactiveDataDisplayManagerExample.xcodeproj/xcshareddata/xcschemes/ReactiveDataDisplayManagerExampleUITests.xcscheme
+++ b/Example/ReactiveDataDisplayManagerExample.xcodeproj/xcshareddata/xcschemes/ReactiveDataDisplayManagerExampleUITests.xcscheme
@@ -4,8 +4,7 @@
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      runPostActionsOnFailure = "NO">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -27,10 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      onlyGenerateCoverageForSpecifiedTargets = "NO"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -40,8 +36,8 @@
             ReferencedContainer = "container:ReactiveDataDisplayManagerExample.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <CommandLineArguments>
-      </CommandLineArguments>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -62,8 +58,6 @@
             ReferencedContainer = "container:ReactiveDataDisplayManagerExample.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -81,8 +75,6 @@
             ReferencedContainer = "container:ReactiveDataDisplayManagerExample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Example/ReactiveDataDisplayManagerExampleUITests/BaseClasses/BaseUITestCase.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/BaseClasses/BaseUITestCase.swift
@@ -1,0 +1,51 @@
+//
+//  BaseUITestCase.swift
+//  ReactiveDataDisplayManagerExampleUITests
+//
+//  Created by porohov on 14.06.2022.
+//
+
+import XCTest
+
+open class BaseUITestCase: XCTestCase {
+
+    enum CollectionType {
+        case table, collection
+    }
+
+    //swiftlint:disable:next implicitly_unwrapped_optional
+    var app: XCUIApplication!
+
+    override open func setUpWithError() throws {
+        try super.setUpWithError()
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments.append("-disableAnimations")
+        app.launch()
+    }
+
+    func setTab(_ screenName: String) {
+        app.tabBars.buttons[screenName].tap()
+    }
+
+    func tapTableElement(_ screenName: String) {
+        app.tables.staticTexts[screenName].tap()
+    }
+
+    func tapButton(_ screenName: String) {
+        app.buttons[screenName].tap()
+    }
+
+    func getFirstCell(for collection: CollectionType, id: String) -> XCUIElement {
+        let collection = (collection == .collection ? app.collectionViews : app.tables)
+            .matching(identifier: id)
+        return collection.cells.firstMatch
+    }
+
+    func getCell(for collection: CollectionType, collectionId: String, cellId: String) -> XCUIElement {
+        let collection = (collection == .collection ? app.collectionViews : app.tables)
+            .matching(identifier: collectionId)
+        return collection.cells.element(matching: .cell, identifier: cellId)
+    }
+
+}

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/DragAndDroppablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/DragAndDroppablePluginExampleUITest.swift
@@ -1,0 +1,55 @@
+//
+//  DragAndDroppablePluginExampleUITest.swift
+//  ReactiveDataDisplayManagerExampleUITests
+//
+//  Created by porohov on 14.06.2022.
+//
+
+
+import XCTest
+
+final class DragAndDroppablePluginExampleUITest: BaseUITestCase {
+
+    private enum Constants {
+        static let dragDuration = 0.3
+        static let waitTime: UInt32 = 1
+    }
+
+    func testСollection_whenFirstCellDragingToDestination_thenDestinationCellBecomesFirst() throws {
+        let collectionId = "Collection_with_drag_n_drop_items"
+        let sourceDraggable = "Cell: 11"
+        let destinationDraggable = "Cell: 12"
+        let duration = Constants.dragDuration
+
+        setTab("Collection")
+        tapTableElement("Collection with drag and drop item")
+
+        let sourceCell = getCell(for: .collection, collectionId: collectionId, cellId: sourceDraggable)
+        let destinationCell = getCell(for: .collection, collectionId: collectionId, cellId: destinationDraggable)
+        sourceCell.press(forDuration: duration, thenDragTo: destinationCell, withVelocity: .slow, thenHoldForDuration: duration)
+
+        sleep(Constants.waitTime)
+        let firstCell = getFirstCell(for: .collection, id: collectionId)
+
+        XCTAssertTrue(firstCell.label == destinationDraggable)
+    }
+
+    func testTable_whenFirstCellDragingToDestination_thenDestinationCellBecomesFirst() throws {
+        let tableId = "Table_with_drag_n_drop_cell"
+        let sourceDraggable = "Cell: 1"
+        let destinationDraggable = "Cell: 2"
+        let duration = Constants.dragDuration
+
+        setTab("Table")
+        tapTableElement("Table with drag and drop cells")
+
+        let sourceCell = getCell(for: .table, collectionId: tableId, cellId: sourceDraggable)
+        let destinationCell = getCell(for: .table, collectionId: tableId, cellId: destinationDraggable)
+        sourceCell.press(forDuration: duration, thenDragTo: destinationCell, withVelocity: .slow, thenHoldForDuration: duration)
+
+        sleep(Constants.waitTime)
+        let firstCell = getFirstCell(for: .table, id: tableId)
+        XCTAssertTrue(firstCell.label == destinationDraggable)
+    }
+
+}

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/MovablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/MovablePluginExampleUITest.swift
@@ -1,0 +1,56 @@
+//
+//  MovablePluginExampleUITest.swift
+//  ReactiveDataDisplayManagerExampleUITests
+//
+//  Created by porohov on 14.06.2022.
+//
+
+import XCTest
+
+final class MovablePluginExampleUITest: BaseUITestCase {
+
+    private enum Constants {
+        static let dragDuration = 0.5
+        static let waitTime: UInt32 = 1
+    }
+
+    func testСollection_whenFirstCellDragingToDestination_thenDestinationCellBecomesFirst() throws {
+        let collectionId = "Collection_with_movable_cell"
+        let sourceDraggable = "Cell 0"
+        let destinationDraggable = "Cell 1"
+        let duration = Constants.dragDuration
+
+        setTab("Collection")
+        tapTableElement("Collection with movable items")
+
+        let sourceCell = getCell(for: .collection, collectionId: collectionId, cellId: sourceDraggable)
+        let destinationCell = getCell(for: .collection, collectionId: collectionId, cellId: destinationDraggable)
+        sourceCell.press(forDuration: duration, thenDragTo: destinationCell, withVelocity: .slow, thenHoldForDuration: duration)
+
+        sleep(Constants.waitTime)
+        let firstCell = getFirstCell(for: .collection, id: collectionId)
+
+        XCTAssertTrue(firstCell.label == destinationDraggable)
+    }
+
+    func testTable_whenFirstCellDragingToDestination_thenDestinationCellBecomesFirst() throws {
+        let tableId = "Table_with_movable_cell"
+        let sourceDraggable = "Cell: 1"
+        let duration = Constants.dragDuration
+
+        setTab("Table")
+        tapTableElement("Table with movable cell")
+
+        let sourceCell = getCell(for: .table, collectionId: tableId, cellId: sourceDraggable)
+        let destinationSection = app.tables[tableId].otherElements["Section 2"]
+
+        sourceCell.buttons.firstMatch
+            .press(forDuration: duration, thenDragTo: destinationSection, withVelocity: .slow, thenHoldForDuration: duration)
+
+        sleep(Constants.waitTime)
+        let firstCell = getFirstCell(for: .table, id: tableId)
+
+        XCTAssertTrue(firstCell.label == "Cell: 2")
+    }
+
+}

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/SelectablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/SelectablePluginExampleUITest.swift
@@ -7,18 +7,7 @@
 
 import XCTest
 
-final class SelectablePluginExampleUITest: XCTestCase {
-
-    //swiftlint:disable:next implicitly_unwrapped_optional
-    var app: XCUIApplication!
-
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        continueAfterFailure = false
-        app = XCUIApplication()
-        app.launchArguments.append("-disableAnimations")
-        app.launch()
-    }
+final class SelectablePluginExampleUITest: BaseUITestCase {
 
     func testTableMultipleTap_whenCellTaped_thenCellSelected_thenCellDeselected() throws {
         setTab("Table")
@@ -70,32 +59,6 @@ final class SelectablePluginExampleUITest: XCTestCase {
             cell.tap()
             XCTAssertFalse(cell.isSelected)
         }
-    }
-
-}
-
-private extension SelectablePluginExampleUITest {
-
-    enum CollectionType {
-        case table, collection
-    }
-
-    func setTab(_ screenName: String) {
-        app.tabBars.buttons[screenName].tap()
-    }
-
-    func tapTableElement(_ screenName: String) {
-        app.tables.staticTexts[screenName].tap()
-    }
-
-    func tapButton(_ screenName: String) {
-        app.buttons[screenName].tap()
-    }
-
-    func getFirstCell(for collection: CollectionType, id: String) -> XCUIElement {
-        let collection = (collection == .collection ? app.collectionViews : app.tables)
-            .matching(identifier: id)
-        return collection.cells.firstMatch
     }
 
 }

--- a/Example/ReactiveDataDisplayManagerExampleUITests/ReactiveDataDisplayManagerExampleUITests.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/ReactiveDataDisplayManagerExampleUITests.swift
@@ -7,18 +7,7 @@
 
 import XCTest
 
-class ReactiveDataDisplayManagerExampleUITests: XCTestCase {
-
-    //swiftlint:disable:next implicitly_unwrapped_optional
-    var app: XCUIApplication!
-
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        continueAfterFailure = false
-        app = XCUIApplication()
-        app.launchArguments.append("-disableAnimations")
-        app.launch()
-    }
+class ReactiveDataDisplayManagerExampleUITests: BaseUITestCase {
 
     func testCollectionScreen() throws {
         setTab("Collection")
@@ -39,10 +28,6 @@ class ReactiveDataDisplayManagerExampleUITests: XCTestCase {
 // MARK: - Private methods
 
 private extension ReactiveDataDisplayManagerExampleUITests {
-
-    func setTab(_ screenName: String) {
-        app.tabBars.buttons[screenName].tap()
-    }
 
     func assertAllScreensOpeningWithoutCrashes() {
         let tablesQuery = app.tables


### PR DESCRIPTION

## Что сделано?

- Сделал тесты для dragAndDroppable и movable плагинов
- Исправил проблему перетаскивания ячеек в MovableCollectionViewController и MovableTableViewController отключив у коллекций dragInteractionEnabled

## Зачем это сделано?

Нужно для поддержания плагинов в рабочем состоянии при импакте либы

## Как протестировать?

- Запустить MovablePluginExampleUITest и DragAndDroppablePluginExampleUITest
