### PR TITLE
make drag'n'drop test faster and more stable

### DIFF
--- a/Example/ReactiveDataDisplayManager/Collection/DragAndDroppableCollectionViewController/DragAndDroppableCollectionViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Collection/DragAndDroppableCollectionViewController/DragAndDroppableCollectionViewController.swift
@@ -76,7 +76,7 @@ private extension DragAndDroppableCollectionViewController {
     func makeCellGenerators(for range: [Int]) -> [CollectionCellGenerator] {
         var generators = [CollectionCellGenerator]()
 
-        for index in 11...20 {
+        for index in range {
             let generator = TitleCollectionGenerator(model: "Cell: \(index)")
             generators.append(generator)
         }

--- a/Example/ReactiveDataDisplayManagerExample.xcodeproj/xcshareddata/xcschemes/ReactiveDataDisplayManagerExampleUITests.xcscheme
+++ b/Example/ReactiveDataDisplayManagerExample.xcodeproj/xcshareddata/xcschemes/ReactiveDataDisplayManagerExampleUITests.xcscheme
@@ -4,7 +4,8 @@
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -26,7 +27,10 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -36,8 +40,8 @@
             ReferencedContainer = "container:ReactiveDataDisplayManagerExample.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <Testables>
-      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -58,6 +62,8 @@
             ReferencedContainer = "container:ReactiveDataDisplayManagerExample.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -75,6 +81,8 @@
             ReferencedContainer = "container:ReactiveDataDisplayManagerExample.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/DragAndDroppablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/DragAndDroppablePluginExampleUITest.swift
@@ -5,7 +5,6 @@
 //  Created by porohov on 14.06.2022.
 //
 
-
 import XCTest
 
 final class DragAndDroppablePluginExampleUITest: BaseUITestCase {

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/DragAndDroppablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/DragAndDroppablePluginExampleUITest.swift
@@ -17,8 +17,8 @@ final class DragAndDroppablePluginExampleUITest: BaseUITestCase {
 
     func testСollection_whenFirstCellDragingToDestination_thenDestinationCellBecomesFirst() throws {
         let collectionId = "Collection_with_drag_n_drop_items"
-        let sourceDraggable = "Cell: 11"
-        let destinationDraggable = "Cell: 12"
+        let sourceDraggable = "Cell: 1"
+        let destinationDraggable = "Cell: 2"
         let duration = Constants.dragDuration
 
         setTab("Collection")


### PR DESCRIPTION
## Что сделано?

- Поправлен пример и тест
- ...

## Зачем это сделано?

Чтобы тесты были зеленее и стабильнее

## На что обратить внимание?

- Упало на develop, а локально я не гонял прошлы ПР.
- В GithubActions тоже упало, но там индикация сломана. (Надо починить, чтобы падение фейлило сборку)
- ...

## Как протестировать?

- Запустить тест DragAndDroppablePluginExampleUITest
