### PR TITLE
Highlightable plugin test. Adding select methods to the plugin

### DIFF
--- a/Example/ReactiveDataDisplayManager/Collection/Views/Cells/TitleCollectionViewCell/TitleCollectionViewCell.swift
+++ b/Example/ReactiveDataDisplayManager/Collection/Views/Cells/TitleCollectionViewCell/TitleCollectionViewCell.swift
@@ -39,19 +39,23 @@ extension TitleCollectionViewCell: HighlightableItem {
 
     func applyUnhighlightedStyle() {
         contentView.backgroundColor = .gray
+        accessibilityLabel = "Normal"
     }
 
     func applyHighlightedStyle() {
         contentView.backgroundColor = .white.withAlphaComponent(0.5)
+        accessibilityLabel = "Highlighted"
     }
 
     func applySelectedStyle() {
         contentView.layer.borderColor = UIColor.blue.cgColor
         contentView.layer.borderWidth = 1
+        accessibilityLabel = "Selected"
     }
 
     func applyDeselectedStyle() {
         contentView.layer.borderWidth = .zero
+        accessibilityLabel = "Normal"
     }
 
 }

--- a/Example/ReactiveDataDisplayManager/Collection/Views/Cells/TitleCollectionViewCell/TitleCollectionViewCell.swift
+++ b/Example/ReactiveDataDisplayManager/Collection/Views/Cells/TitleCollectionViewCell/TitleCollectionViewCell.swift
@@ -37,12 +37,21 @@ extension TitleCollectionViewCell: ConfigurableItem {
 
 extension TitleCollectionViewCell: HighlightableItem {
 
-    func applyNormalStyle() {
+    func applyUnhighlightedStyle() {
         contentView.backgroundColor = .gray
     }
 
     func applyHighlightedStyle() {
         contentView.backgroundColor = .white.withAlphaComponent(0.5)
+    }
+
+    func applySelectedStyle() {
+        contentView.layer.borderColor = UIColor.blue.cgColor
+        contentView.layer.borderWidth = 1
+    }
+
+    func applyDeselectedStyle() {
+        contentView.layer.borderWidth = .zero
     }
 
 }

--- a/Example/ReactiveDataDisplayManager/Table/HighlightableTableTableViewController/HighlightableTableTableViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Table/HighlightableTableTableViewController/HighlightableTableTableViewController.swift
@@ -32,6 +32,7 @@ final class HighlightableTableViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Higlighted cells"
+        tableView.accessibilityIdentifier = "Higlighted_cells"
         fillAdapter()
         updateBarButtonItem(with: Constants.standart)
     }

--- a/Example/ReactiveDataDisplayManager/Table/HighlightableTableTableViewController/HighlightableTableTableViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Table/HighlightableTableTableViewController/HighlightableTableTableViewController.swift
@@ -13,6 +13,8 @@ final class HighlightableTableViewController: UIViewController {
 
     private enum Constants {
         static let models = [String](repeating: "Cell", count: 10)
+        static let standart = "Single mode"
+        static let multiple = "Multiple mode"
     }
 
     // MARK: - IBOutlet
@@ -29,8 +31,9 @@ final class HighlightableTableViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Table with swipeable cells"
+        title = "Higlighted cells"
         fillAdapter()
+        updateBarButtonItem(with: Constants.standart)
     }
 
 }
@@ -51,6 +54,18 @@ private extension HighlightableTableViewController {
 
         // Tell adapter that we've changed generators
         adapter.forceRefill()
+    }
+
+    func updateBarButtonItem(with title: String) {
+        let button = UIBarButtonItem(title: title, style: .plain, target: self, action: #selector(toggleAllowsMultiple))
+        navigationItem.rightBarButtonItem = button
+    }
+
+    @objc
+    func toggleAllowsMultiple() {
+        adapter.generators.forEach { $0.forEach { ($0 as? SelectableItem)?.isNeedDeselect.toggle() } }
+        adapter.view.allowsMultipleSelection.toggle()
+        updateBarButtonItem(with: tableView.allowsMultipleSelection ? Constants.multiple : Constants.standart)
     }
 
 }

--- a/Example/ReactiveDataDisplayManager/Table/Views/Cells/HighlightableTableCell/HighlightableTableCell.swift
+++ b/Example/ReactiveDataDisplayManager/Table/Views/Cells/HighlightableTableCell/HighlightableTableCell.swift
@@ -41,12 +41,21 @@ extension HighlightableTableCell: ConfigurableItem {
 
 extension HighlightableTableCell: HighlightableItem {
 
-    func applyNormalStyle() {
+    func applyUnhighlightedStyle() {
         contentView.backgroundColor = .white
     }
 
     func applyHighlightedStyle() {
         contentView.backgroundColor = .red.withAlphaComponent(0.3)
+    }
+
+    func applySelectedStyle() {
+        contentView.layer.borderColor = UIColor.blue.cgColor
+        contentView.layer.borderWidth = 1
+    }
+
+    func applyDeselectedStyle() {
+        contentView.layer.borderWidth = .zero
     }
 
 }

--- a/Example/ReactiveDataDisplayManager/Table/Views/Cells/HighlightableTableCell/HighlightableTableCell.swift
+++ b/Example/ReactiveDataDisplayManager/Table/Views/Cells/HighlightableTableCell/HighlightableTableCell.swift
@@ -43,19 +43,23 @@ extension HighlightableTableCell: HighlightableItem {
 
     func applyUnhighlightedStyle() {
         contentView.backgroundColor = .white
+        accessibilityLabel = "Normal"
     }
 
     func applyHighlightedStyle() {
         contentView.backgroundColor = .red.withAlphaComponent(0.3)
+        accessibilityLabel = "Highlighted"
     }
 
     func applySelectedStyle() {
         contentView.layer.borderColor = UIColor.blue.cgColor
         contentView.layer.borderWidth = 1
+        accessibilityLabel = "Selected"
     }
 
     func applyDeselectedStyle() {
         contentView.layer.borderWidth = .zero
+        accessibilityLabel = "Normal"
     }
 
 }

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/HighlightablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/HighlightablePluginExampleUITest.swift
@@ -1,0 +1,85 @@
+//
+//  HighlightablePluginExampleUITest.swift
+//  ReactiveDataDisplayManagerExample
+//
+//  Created by porohov on 17.06.2022.
+//
+
+import XCTest
+
+final class HighlightablePluginExampleUITest: BaseUITestCase {
+
+    func testTable_whenCellTaped_thenCellhighlighted() throws {
+        let normalStyle = "Normal"
+        let highlightedStyle = "Highlighted"
+
+        setTab("Table")
+        tapTableElement("Table with highlightable cells")
+
+        let cell = getFirstCell(for: .table, id: "Higlighted_cells")
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            XCTAssertTrue(cell.label == highlightedStyle)
+        }
+        cell.press(forDuration: 2)
+
+        XCTAssertEqual(cell.label, normalStyle)
+    }
+
+    func testTable_whenCellTaped_thenTurnedSelectStyleAndDeselectStyle() throws {
+        let selectedStyle = "Selected"
+        let normalStyle = "Normal"
+
+        setTab("Table")
+        tapTableElement("Table with highlightable cells")
+        tapButton("Single mode")
+
+        let cell = getFirstCell(for: .table, id: "Higlighted_cells")
+
+        cell.tap()
+        XCTAssertEqual(cell.label, selectedStyle)
+        XCTAssertTrue(cell.isSelected)
+
+        cell.tap()
+        XCTAssertEqual(cell.label, normalStyle)
+        XCTAssertFalse(cell.isSelected)
+    }
+
+    func testCollection_whenCellTaped_thenCellhighlighted() throws {
+        let normalStyle = "Normal"
+        let highlightedStyle = "Highlighted"
+
+        setTab("Collection")
+        tapTableElement("Base collection view")
+
+        let cell = getFirstCell(for: .collection, id: "Collection_with_selectable_cells")
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            XCTAssertTrue(cell.label == highlightedStyle)
+        }
+        cell.press(forDuration: 2)
+
+        XCTAssertTrue(cell.label == normalStyle)
+    }
+
+    func testCollection_whenCellTaped_thenTurnedSelectStyleAndDeselectStyle() throws {
+        let selectedStyle = "Selected"
+        let normalStyle = "Normal"
+
+        setTab("Collection")
+        tapTableElement("Base collection view")
+        tapButton("Single mode")
+
+        let cell = getFirstCell(for: .collection, id: "Collection_with_selectable_cells")
+
+        cell.tap()
+        XCTAssertEqual(cell.label, selectedStyle)
+        XCTAssertTrue(cell.isSelected)
+
+        cell.tap()
+        XCTAssertEqual(cell.label, normalStyle)
+        XCTAssertFalse(cell.isSelected)
+    }
+
+}
+

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/HighlightablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/HighlightablePluginExampleUITest.swift
@@ -82,4 +82,3 @@ final class HighlightablePluginExampleUITest: BaseUITestCase {
     }
 
 }
-

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/HighlightablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/HighlightablePluginExampleUITest.swift
@@ -12,17 +12,23 @@ final class HighlightablePluginExampleUITest: BaseUITestCase {
     func testTable_whenCellTaped_thenCellhighlighted() throws {
         let normalStyle = "Normal"
         let highlightedStyle = "Highlighted"
+        let expectation = XCTestExpectation(description: "Cell Pressed")
+        let timeout: TimeInterval = 1
+        var wasPresed = false
 
         setTab("Table")
         tapTableElement("Table with highlightable cells")
 
         let cell = getFirstCell(for: .table, id: "Higlighted_cells")
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            XCTAssertEqual(cell.label, highlightedStyle)
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
+            wasPresed = cell.label == highlightedStyle
+            expectation.fulfill()
         }
         cell.press(forDuration: 2)
 
+        wait(for: [expectation], timeout: timeout)
+        XCTAssertTrue(wasPresed)
         XCTAssertEqual(cell.label, normalStyle)
     }
 
@@ -48,17 +54,23 @@ final class HighlightablePluginExampleUITest: BaseUITestCase {
     func testCollection_whenCellTaped_thenCellhighlighted() throws {
         let normalStyle = "Normal"
         let highlightedStyle = "Highlighted"
+        let expectation = XCTestExpectation(description: "Cell Pressed")
+        let timeout: TimeInterval = 1
+        var wasPresed = false
 
         setTab("Collection")
         tapTableElement("Base collection view")
 
         let cell = getFirstCell(for: .collection, id: "Collection_with_selectable_cells")
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            XCTAssertEqual(cell.label, highlightedStyle)
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
+            wasPresed = cell.label == highlightedStyle
+            expectation.fulfill()
         }
         cell.press(forDuration: 2)
 
+        wait(for: [expectation], timeout: timeout)
+        XCTAssertTrue(wasPresed)
         XCTAssertEqual(cell.label, normalStyle)
     }
 

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/HighlightablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/HighlightablePluginExampleUITest.swift
@@ -19,7 +19,7 @@ final class HighlightablePluginExampleUITest: BaseUITestCase {
         let cell = getFirstCell(for: .table, id: "Higlighted_cells")
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            XCTAssertTrue(cell.label == highlightedStyle)
+            XCTAssertEqual(cell.label, highlightedStyle)
         }
         cell.press(forDuration: 2)
 
@@ -55,11 +55,11 @@ final class HighlightablePluginExampleUITest: BaseUITestCase {
         let cell = getFirstCell(for: .collection, id: "Collection_with_selectable_cells")
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            XCTAssertTrue(cell.label == highlightedStyle)
+            XCTAssertEqual(cell.label, highlightedStyle)
         }
         cell.press(forDuration: 2)
 
-        XCTAssertTrue(cell.label == normalStyle)
+        XCTAssertEqual(cell.label, normalStyle)
     }
 
     func testCollection_whenCellTaped_thenTurnedSelectStyleAndDeselectStyle() throws {

--- a/Source/Collection/Plugins/PluginAction/CollectionHighlightPlugin.swift
+++ b/Source/Collection/Plugins/PluginAction/CollectionHighlightPlugin.swift
@@ -7,18 +7,26 @@
 
 import UIKit
 
-// MARK: - Item
+/// Plugin to support `HighlightableItem`
+///
+/// Provides the cell with update methods on selection, deselection, highlightion, unhighlightion
+public class CollectionHighlightPlugin: BaseCollectionPlugin<CollectionEvent> {
 
-public protocol HighlightableItem {
+    // MARK: - Private Properties
 
-    func applyNormalStyle()
-    func applyHighlightedStyle()
+    private let animationDuration: TimeInterval
+    private let animationDelay: TimeInterval
 
-}
+    // MARK: - Initialization
 
-final class CollectionHighlightPlugin: BaseCollectionPlugin<CollectionEvent> {
+    init(animationDuration: TimeInterval, animationDelay: TimeInterval) {
+        self.animationDuration = animationDuration
+        self.animationDelay = animationDelay
+    }
 
-    override func process(event: CollectionEvent, with manager: BaseCollectionManager?) {
+    // MARK: - BaseCollectionPlugin
+
+    public override func process(event: CollectionEvent, with manager: BaseCollectionManager?) {
 
         switch event {
         case .didHighlight(let indexPath):
@@ -34,11 +42,37 @@ final class CollectionHighlightPlugin: BaseCollectionPlugin<CollectionEvent> {
                       return
                   }
 
-            highlightable.applyNormalStyle()
+            highlightable.applyUnhighlightedStyle()
+        case .didSelect(let indexPath):
+            guard let cell = manager?.view.cellForItem(at: indexPath),
+                  let highlightable = cell as? HighlightableItem else {
+                      return
+                  }
+
+            highlightable.applySelectedStyle()
+            animationDeselect(cell: highlightable, manager: manager, indexPath: indexPath)
+        case .didDeselect(let indexPath):
+            guard let cell = manager?.view.cellForItem(at: indexPath),
+                  let highlightable = cell as? HighlightableItem else {
+                      return
+                  }
+
+            highlightable.applyDeselectedStyle()
         default:
             break
         }
 
+    }
+
+    // MARK: - Private
+
+    private func animationDeselect(cell: HighlightableItem, manager: BaseCollectionManager?, indexPath: IndexPath) {
+        guard (manager?.generators[indexPath.section][indexPath.row] as? SelectableItem)?.isNeedDeselect == true else {
+            return
+        }
+        UIView.animate(withDuration: animationDuration, delay: animationDelay) {
+            cell.applyDeselectedStyle()
+        }
     }
 
 }
@@ -49,10 +83,17 @@ public extension BaseCollectionPlugin {
 
     /// Plugin to support `HighlightableItem`
     ///
-    /// Handle `didHighlight` event by changing `contentView` style to `HighlightableItem.highlightedStyle`
-    /// Handle `didUnhighlight` event by changing `contentView` style to `HighlightableItem.normalStyle`
-    static func highlightable() -> BaseCollectionPlugin<CollectionEvent> {
-        CollectionHighlightPlugin()
+    /// Handle `didHighlight` event by changing `contentView` style in the `HighlightableItem.applyHighlightedStyle`
+    /// Handle `didUnhighlight` event by changing `contentView` style in the  `HighlightableItem.applyUnhighlightedStyle`
+    /// Handle `didSelect` event by changing `contentView` style in the  `HighlightableItem.applySelectedStyle`
+    /// Handle `didDeselect` event by changing `contentView` style in the  `HighlightableItem.applyDeselectedStyle`
+    ///
+    /// - Parameters:
+    ///     - animationDuration: autodeselect cell animation duration, default value = 0.3
+    ///     - animationDelay: autodeselect cell delay, default value = 0
+    static func highlightable(animationDuration: TimeInterval = 0.3,
+                              animationDelay: TimeInterval = .zero) -> BaseCollectionPlugin<CollectionEvent> {
+        CollectionHighlightPlugin(animationDuration: animationDuration, animationDelay: animationDelay)
     }
 
 }

--- a/Source/Protocols/Plugins/Generators/HighlightableItem.swift
+++ b/Source/Protocols/Plugins/Generators/HighlightableItem.swift
@@ -1,0 +1,34 @@
+//
+//  HighlightableItem.swift
+//  Pods
+//
+//  Created by porohov on 23.06.2022.
+//
+
+import Foundation
+
+/// Protocol for `Cell` to manage selectable style
+public protocol HighlightableItem {
+
+    /// Invokes when user taps on the item.
+    func applyUnhighlightedStyle()
+
+    /// Called when the user takes their finger off the element.
+    func applyHighlightedStyle()
+
+    /// Invokes when user taps on the item. Remains selected if `SelectableItem.isNeedDeselect == true`
+    func applySelectedStyle()
+
+    /// Called when the user clicks the selected cell again. Depends on collection `allowsMultipleSelection`
+    func applyDeselectedStyle()
+}
+
+// MARK: - Default
+
+public extension HighlightableItem {
+
+    func applyUnhighlightedStyle() { }
+    func applyHighlightedStyle() { }
+    func applySelectedStyle() { }
+    func applyDeselectedStyle() { }
+}

--- a/Source/Table/Plugins/PluginAction/TableHighlightPlugin.swift
+++ b/Source/Table/Plugins/PluginAction/TableHighlightPlugin.swift
@@ -5,7 +5,7 @@
 //  Created by porohov on 14.06.2022.
 //
 
-import Foundation
+import UIKit
 
 /// Plugin to support `HighlightableItem`
 ///

--- a/Source/Table/Plugins/PluginAction/TableHighlightPlugin.swift
+++ b/Source/Table/Plugins/PluginAction/TableHighlightPlugin.swift
@@ -7,9 +7,26 @@
 
 import Foundation
 
-final class TableHighlightPlugin: BaseTablePlugin<TableEvent> {
+/// Plugin to support `HighlightableItem`
+///
+/// Provides the cell with update methods on selection, deselection, highlightion, unhighlightion
+public class TableHighlightPlugin: BaseTablePlugin<TableEvent> {
 
-    override func process(event: TableEvent, with manager: BaseTableManager?) {
+    // MARK: - Private Properties
+
+    private let animationDuration: TimeInterval
+    private let animationDelay: TimeInterval
+
+    // MARK: - Initialization
+
+    init(animationDuration: TimeInterval, animationDelay: TimeInterval) {
+        self.animationDuration = animationDuration
+        self.animationDelay = animationDelay
+    }
+
+    // MARK: - BaseTablePlugin
+
+    public override func process(event: TableEvent, with manager: BaseTableManager?) {
 
         switch event {
         case .didHighlight(let indexPath):
@@ -25,9 +42,35 @@ final class TableHighlightPlugin: BaseTablePlugin<TableEvent> {
                       return
                   }
 
-            highlightable.applyNormalStyle()
+            highlightable.applyUnhighlightedStyle()
+        case .didSelect(let indexPath):
+            guard let cell = manager?.view.cellForRow(at: indexPath),
+                  let highlightable = cell as? HighlightableItem else {
+                      return
+                  }
+
+            highlightable.applySelectedStyle()
+            animationDeselect(cell: highlightable, manager: manager, indexPath: indexPath)
+        case .didDeselect(let indexPath):
+            guard let cell = manager?.view.cellForRow(at: indexPath),
+                  let highlightable = cell as? HighlightableItem else {
+                      return
+                  }
+
+            highlightable.applyDeselectedStyle()
         default:
             break
+        }
+    }
+
+    // MARK: - Private
+
+    private func animationDeselect(cell: HighlightableItem, manager: BaseTableManager?, indexPath: IndexPath) {
+        guard (manager?.generators[indexPath.section][indexPath.row] as? SelectableItem)?.isNeedDeselect == true else {
+            return
+        }
+        UIView.animate(withDuration: animationDuration, delay: animationDelay) {
+            cell.applyDeselectedStyle()
         }
     }
 
@@ -39,10 +82,17 @@ public extension BaseTablePlugin {
 
     /// Plugin to support `HighlightableItem`
     ///
-    /// Handle `didHighlight` event by changing `contentView` style to `HighlightableItem.highlightedStyle`
-    /// Handle `didUnhighlight` event by changing `contentView` style to `HighlightableItem.normalStyle`
-    static func highlightable() -> BaseTablePlugin<TableEvent> {
-        TableHighlightPlugin()
+    /// Handle `didHighlight` event by changing `contentView` style in the `HighlightableItem.applyHighlightedStyle`
+    /// Handle `didUnhighlight` event by changing `contentView` style in the  `HighlightableItem.applyUnhighlightedStyle`
+    /// Handle `didSelect` event by changing `contentView` style in the  `HighlightableItem.applySelectedStyle`
+    /// Handle `didDeselect` event by changing `contentView` style in the  `HighlightableItem.applyDeselectedStyle`
+    ///
+    /// - Parameters:
+    ///     - animationDuration: autodeselect cell animation duration, default value = 0.3
+    ///     - animationDelay: autodeselect cell delay, default value = 0
+    static func highlightable(animationDuration: TimeInterval = 0.3,
+                              animationDelay: TimeInterval = .zero) -> BaseTablePlugin<TableEvent> {
+        TableHighlightPlugin(animationDuration: animationDuration, animationDelay: animationDelay)
     }
 
 }


### PR DESCRIPTION

## Что сделано?

- Модифицировал Highlightable plugin методами селекта/деселекта
- Добавил документацию к плагину
- Добавил реализацию в example
- Написал тесты на все кейсы
- ...

## Зачем это сделано?

Стандартный selectionStyle у таблицы редко когда подходит, а у коллекции его вообще нет, поэтому было принято решение сделать так чтоб можно было применять стиль на выделенную ячейку

## На что обратить внимание?

- Сделал автодеселект с анимацией завязанном на SelectableItem (оттуда получаем флаг isNeedDeselect)
- ...

## Как протестировать?

- Запустить
- Таб "Collection"
- Первая ячейка
или
- Taб "Table"
- Последняя ячейка

тесты
- Запустить тест HighlightablePluginExampleUITest
