### PR TITLE
IDPT-644 RDDM. Решить проблему Foldable плагина с приведением базового генератора к конкретному типу

### DIFF
--- a/Source/Table/Plugins/PluginAction/TableFoldablePlugin.swift
+++ b/Source/Table/Plugins/PluginAction/TableFoldablePlugin.swift
@@ -55,6 +55,8 @@ private extension TableFoldablePlugin {
             manager.insert(after: generator, new: childGenerators, with: .fade)
         } else if let manager = manager as? GravityTableManager {
             manager.addCellGenerators(childGenerators, after: generator)
+        } else {
+            assertionFailure("❗️The base manager cannot control the show/hide. Install ManualTableManager or GravityTableManager")
         }
     }
 


### PR DESCRIPTION

## Что сделано?

- Добавил сообщение об ошибке (Базовый мэнеджер не может управлять раскрытием/скрытием. Установите ManualTableManager либо GravityTableManager)

## Зачем это сделано?

- Для того чтобы пользователи не разбирались почему не работает плагин на базовом билдере

## Как протестировать?

- В FoldableTableViewController поменять manualBuilder на baseBuilder
- Запустить и открыть Foldable на таблице
- Нажать на раскрытие ячейки
- Xcode выдаст ошибку
