### PR TITLE
Feature/resolve warnings xcode14

### DIFF
--- a/Example/targets/template.yml
+++ b/Example/targets/template.yml
@@ -24,7 +24,7 @@ targetTemplates:
         type: bundle.ui-testing
         platform: iOS
         deploymentTarget:
-          iOS: 10.0
+          iOS: 11.0
           tvOS: 10.0
         scheme:
           configVariants: all

--- a/Podfile
+++ b/Podfile
@@ -1,11 +1,11 @@
 use_frameworks!
 
 def utils
-  pod 'SurfUtils/ItemsScrollManager', :git => "https://github.com/surfstudio/iOS-Utils.git", :tag => '11.0.0'
+  pod 'SurfUtils/ItemsScrollManager', :git => "https://github.com/surfstudio/iOS-Utils.git", :tag => '13.1.0'
 end
 
 def diffKit
-  pod 'DifferenceKit', '1.1.5'
+  pod 'DifferenceKit', '1.3.0'
 end
 
 def nuke
@@ -27,4 +27,12 @@ abstract_target 'Targets' do
     platform :tvos, '13.0'
   end
 
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11'
+    end
+  end
 end

--- a/Source/Collection/Manager/BaseCollectionManager.swift
+++ b/Source/Collection/Manager/BaseCollectionManager.swift
@@ -183,8 +183,8 @@ extension BaseCollectionManager {
     /// - Parameters:
     ///   - after: Generator after which new generator will be added. Must be in the DDM.
     ///   - new: Generators which you want to insert after current generator.
-    open func insert(after generator: CollectionCellGenerator,
-                     new newGenerators: [CollectionCellGenerator]) {
+    public func insert(after generator: CollectionCellGenerator,
+                       new newGenerators: [CollectionCellGenerator]) {
         guard let index = self.findGenerator(generator) else { return }
 
         let elements = newGenerators.enumerated().map { item in
@@ -201,9 +201,9 @@ extension BaseCollectionManager {
     /// A constant that identifies a relative position in the collection view (top, middle, bottom)
     /// for item when scrolling concludes. See UICollectionViewScrollPosition for descriptions of valid constants.
     ///   - needRemoveEmptySection: Pass **true** if you need to remove section if it'll be empty after deleting.
-    open func remove(_ generator: CollectionCellGenerator,
-                     needScrollAt scrollPosition: UICollectionView.ScrollPosition?,
-                     needRemoveEmptySection: Bool) {
+    public func remove(_ generator: CollectionCellGenerator,
+                       needScrollAt scrollPosition: UICollectionView.ScrollPosition?,
+                       needRemoveEmptySection: Bool) {
         guard let index = findGenerator(generator) else { return }
         self.removeGenerator(with: index,
                              needScrollAt: scrollPosition,

--- a/Source/Protocols/Plugins/FeaturePlugin/MovablePlugin/MovablePluginDataSource.swift
+++ b/Source/Protocols/Plugins/FeaturePlugin/MovablePlugin/MovablePluginDataSource.swift
@@ -32,11 +32,11 @@ extension MovablePluginDataSource: MovableDataSource {
     ///     - with: current provider with generators
     ///     - and: view object requesting this action.
     ///     - animator: an animator object for animating movement
-    open func moveRow<Collection: UIView>(at sourceIndexPath: IndexPath,
-                                          to destinationIndexPath: IndexPath,
-                                          with provider: Provider?,
-                                          and view: Collection,
-                                          animator: Animator<Collection>?) {
+    public func moveRow<Collection: UIView>(at sourceIndexPath: IndexPath,
+                                            to destinationIndexPath: IndexPath,
+                                            with provider: Provider?,
+                                            and view: Collection,
+                                            animator: Animator<Collection>?) {
         let moveToTheSameSection = sourceIndexPath.section == destinationIndexPath.section
         guard
             let provider = provider,
@@ -61,7 +61,7 @@ extension MovablePluginDataSource: MovableDataSource {
     /// - parameters:
     ///     - at: index path of a given item
     ///     - with: current provider with generators
-    open func canMoveRow(at indexPath: IndexPath, with provider: Provider?) -> Bool {
+    public func canMoveRow(at indexPath: IndexPath, with provider: Provider?) -> Bool {
         if let generator = provider?.generators[indexPath.section][indexPath.row] as? GeneratorType {
             return generator.canMove()
         }

--- a/Source/Protocols/Plugins/FeaturePlugin/MovablePlugin/MovablePluginDelegate.swift
+++ b/Source/Protocols/Plugins/FeaturePlugin/MovablePlugin/MovablePluginDelegate.swift
@@ -25,7 +25,7 @@ extension MovablePluginDelegate: MovableDelegate {
     /// - parameters:
     ///     - at: index path of the focused item
     ///     - with: current provider with generators
-    open func canFocusRow(at indexPath: IndexPath, with provider: Provider?) -> Bool {
+    public func canFocusRow(at indexPath: IndexPath, with provider: Provider?) -> Bool {
         if let generator = provider?.generators[indexPath.section][indexPath.row] as? GeneratorType {
             return generator.canMove()
         }

--- a/Source/Table/DataSource/BaseTableDataSource.swift
+++ b/Source/Table/DataSource/BaseTableDataSource.swift
@@ -37,7 +37,7 @@ open class BaseTableDataSource: NSObject, TableDataSource {
 
 extension BaseTableDataSource {
 
-    open func configure<T>(with builder: TableBuilder<T>) where T: BaseTableManager {
+    public func configure<T>(with builder: TableBuilder<T>) where T: BaseTableManager {
 
         modifier = TableCommonModifier(view: builder.view, animator: builder.animator)
 

--- a/Source/Table/DataSource/DiffableTableDataSource.swift
+++ b/Source/Table/DataSource/DiffableTableDataSource.swift
@@ -70,7 +70,7 @@ open class DiffableTableDataSource: UITableViewDiffableDataSource<DiffableItem, 
 @available(iOS 13.0, tvOS 13.0, *)
 extension DiffableTableDataSource {
 
-    open func configure<T>(with builder: TableBuilder<T>) where T: BaseTableManager {
+    public func configure<T>(with builder: TableBuilder<T>) where T: BaseTableManager {
 
         modifier = TableDiffableModifier(view: builder.view, provider: builder.manager, dataSource: self)
 

--- a/Source/Table/Delegate/BaseTableDelegate.swift
+++ b/Source/Table/Delegate/BaseTableDelegate.swift
@@ -62,7 +62,7 @@ open class BaseTableDelegate: NSObject, TableDelegate {
 
 extension BaseTableDelegate {
 
-    open func configure<T>(with builder: TableBuilder<T>) where T: BaseTableManager {
+    public func configure<T>(with builder: TableBuilder<T>) where T: BaseTableManager {
         animator = builder.animator
 
         movablePlugin = builder.movablePlugin?.delegate

--- a/Source/Table/Plugins/FeaturePlugin/TableMovablePlugin.swift
+++ b/Source/Table/Plugins/FeaturePlugin/TableMovablePlugin.swift
@@ -24,7 +24,7 @@ open class TableMovablePlugin: TableFeaturePlugin {
 @available(iOS, deprecated, renamed: "MovablePlugin")
 extension TableMovablePlugin: TableMovableDelegate {
 
-    open func canMoveRow(at indexPath: IndexPath, with provider: TableGeneratorsProvider?) -> Bool {
+    public func canMoveRow(at indexPath: IndexPath, with provider: TableGeneratorsProvider?) -> Bool {
         if let generator = provider?.generators[indexPath.section][indexPath.row] as? GeneratorType {
             return generator.canMove()
         }
@@ -38,7 +38,7 @@ extension TableMovablePlugin: TableMovableDelegate {
 @available(iOS, deprecated, renamed: "MovablePlugin")
 extension TableMovablePlugin: TableMovableDataSource {
 
-    open func moveRow(at sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath, with provider: TableGeneratorsProvider?) {
+    public func moveRow(at sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath, with provider: TableGeneratorsProvider?) {
         let moveToTheSameSection = sourceIndexPath.section == destinationIndexPath.section
         guard
             let manager = provider as? BaseTableManager,
@@ -64,7 +64,7 @@ extension TableMovablePlugin: TableMovableDataSource {
         }
     }
 
-    open func canFocusRow(at indexPath: IndexPath, with provider: TableGeneratorsProvider?) -> Bool {
+    public func canFocusRow(at indexPath: IndexPath, with provider: TableGeneratorsProvider?) -> Bool {
         if let generator = provider?.generators[indexPath.section][indexPath.row] as? GeneratorType {
             return generator.canMove()
         }

--- a/project.yml
+++ b/project.yml
@@ -18,7 +18,7 @@ targets:
       type: framework
       platform: [iOS, tvOS]
       deploymentTarget:
-        iOS: 10.0
+        iOS: 11.0
         tvOS: 10.0
       scheme:
         configVariants: all
@@ -49,7 +49,7 @@ targets:
       type: bundle.unit-test
       platform: [iOS, tvOS]
       deploymentTarget:
-        iOS: 10.0
+        iOS: 11.0
         tvOS: 10.0
       scheme:
         configVariants: all


### PR DESCRIPTION
## Что сделано?

- Поднята минимальная версия до iOS 11
- Разрешено замечание `non objc instance methods cannot be overiden in extensions`
- ...

## Зачем это сделано?

Для сборки на Xcode 14.x без замечаний

## На что обратить внимание?

- Обновился под DifferenceKit и SurfUtils, используемые в примере
- После мерджа подтянем изменения в develop
- ...

## Как протестировать?

- Проверить сборку и запуск примера
