### PR TITLE
add error state to table paginatable plugin

### DIFF
--- a/Example/ReactiveDataDisplayManager/Extensions/SampleError.swift
+++ b/Example/ReactiveDataDisplayManager/Extensions/SampleError.swift
@@ -1,0 +1,21 @@
+//
+//  SampleError.swift
+//  ReactiveDataDisplayManagerExample_iOS
+//
+//  Created by Никита Коробейников on 27.03.2023.
+//
+
+import Foundation
+
+enum SampleError: Error {
+
+    case sample
+
+    var localizedDescription: String {
+        switch self {
+        case .sample:
+            return "Something went wrong. Please, try again later"
+        }
+    }
+
+}

--- a/Example/ReactiveDataDisplayManager/Extensions/UIButton.swift
+++ b/Example/ReactiveDataDisplayManager/Extensions/UIButton.swift
@@ -1,0 +1,17 @@
+//
+//  UIButton.swift
+//  ReactiveDataDisplayManagerExample_iOS
+//
+//  Created by Никита Коробейников on 27.03.2023.
+//
+
+import UIKit
+
+public extension UIButton {
+
+    static var base: UIButton = {
+        let button = UIButton(type: .roundedRect)
+        return button
+    }()
+
+}

--- a/Example/ReactiveDataDisplayManager/Extensions/UILabel.swift
+++ b/Example/ReactiveDataDisplayManager/Extensions/UILabel.swift
@@ -1,0 +1,20 @@
+//
+//  UILabel.swift
+//  ReactiveDataDisplayManagerExample_iOS
+//
+//  Created by Никита Коробейников on 27.03.2023.
+//
+
+import UIKit
+
+public extension UILabel {
+
+    static var base: UILabel = {
+        let label = UILabel()
+        label.textColor = .systemGray
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+        return label
+    }()
+
+}

--- a/Example/ReactiveDataDisplayManager/Table/PaginatableTableViewController/PaginatableTableViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Table/PaginatableTableViewController/PaginatableTableViewController.swift
@@ -34,6 +34,7 @@ final class PaginatableTableViewController: UIViewController {
 
     private weak var paginatableInput: PaginatableInput?
 
+    private var isFirstPageLoading = true
     private var currentPage = 0
 
     // MARK: - UIViewController
@@ -102,6 +103,15 @@ private extension PaginatableTableViewController {
         TitleTableViewCell.rddm.baseGenerator(with: "Random cell \(Int.random(in: 0...1000)) from page \(currentPage)" )
     }
 
+    func canFillNext() -> Bool {
+        if isFirstPageLoading {
+            isFirstPageLoading.toggle()
+            return false
+        } else {
+            return true
+        }
+    }
+
     func fillNext() -> Bool {
         currentPage += 1
 
@@ -129,10 +139,16 @@ extension PaginatableTableViewController: PaginatableOutput {
         input.updateProgress(isLoading: true)
 
         delay(.now() + .seconds(3)) { [weak self, weak input] in
-            let canIterate = self?.fillNext() ?? false
+            let canFillNext = self?.canFillNext() ?? false
+            if canFillNext {
+                let canIterate = self?.fillNext() ?? false
 
-            input?.updateProgress(isLoading: false)
-            input?.updatePagination(canIterate: canIterate)
+                input?.updateProgress(isLoading: false)
+                input?.updatePagination(canIterate: canIterate)
+            } else {
+                input?.updateProgress(isLoading: false)
+                input?.updateError(SampleError.sample)
+            }
         }
     }
 

--- a/Example/ReactiveDataDisplayManager/Table/Views/PaginatorView.swift
+++ b/Example/ReactiveDataDisplayManager/Table/Views/PaginatorView.swift
@@ -11,7 +11,20 @@ import ReactiveDataDisplayManager
 
 final class PaginatorView: UIView {
 
+    private var retryAction: (() -> Void)?
+
     private lazy var indicator = UIActivityIndicatorView(style: .gray)
+
+    private lazy var errorLabel =  {
+        $0.textAlignment = .center
+        return $0
+    }(UILabel.base)
+
+    private lazy var retryButton = {
+        $0.setTitle("Retry", for: .normal)
+        $0.addTarget(nil, action: #selector(self.onRetryTapped), for: .touchUpInside)
+        return $0
+    }(UIButton.base)
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -26,6 +39,7 @@ final class PaginatorView: UIView {
     private func setupInitialState() {
         backgroundColor = .clear
         addActvityIndicator()
+        addErrorStateViews()
     }
 
     private func addActvityIndicator() {
@@ -38,14 +52,57 @@ final class PaginatorView: UIView {
             indicator.centerYAnchor.constraint(equalTo: self.centerYAnchor)
         ])
     }
+
+    private func addErrorStateViews() {
+        addSubview(errorLabel)
+        addSubview(retryButton)
+
+        errorLabel.translatesAutoresizingMaskIntoConstraints = false
+        retryButton.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            errorLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            errorLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            errorLabel.topAnchor.constraint(equalTo: topAnchor, constant: 16),
+            retryButton.topAnchor.constraint(equalTo: errorLabel.bottomAnchor, constant: 8),
+            retryButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16),
+            retryButton.centerXAnchor.constraint(equalTo: centerXAnchor)
+        ])
+
+        errorLabel.isHidden = true
+        retryButton.isHidden = true
+    }
+
+    @objc
+    private func onRetryTapped() {
+        showError(nil)
+        retryAction?()
+    }
 }
 
 // MARK: - ProgressDisplayableItem
 
 extension PaginatorView: ProgressDisplayableItem {
 
+    func setOnRetry(action: @autoclosure @escaping () -> Void) {
+        retryAction = action
+    }
+
     func showProgress(_ isLoading: Bool) {
         isLoading ? indicator.startAnimating() : indicator.stopAnimating()
+    }
+
+    func showError(_ error: Error?) {
+        if let error {
+            errorLabel.isHidden = false
+            retryButton.isHidden = false
+
+            // It's recommended to override localizedDescription or parse error to user-friendly text in other way
+            errorLabel.text = (error as? SampleError)?.localizedDescription
+        } else {
+            errorLabel.isHidden = true
+            retryButton.isHidden = true
+        }
     }
 
 }

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/PaginatablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/PaginatablePluginExampleUITest.swift
@@ -21,7 +21,16 @@ final class PaginatablePluginExampleUITest: BaseUITestCase {
         tapTableElement("Table with pagination")
 
         let table = app.tables.firstMatch
+        let retryButton = app.buttons["Retry"]
+
         XCTAssertTrue(table.waitForExistence(timeout: Constants.timeout))
+        XCTAssertTrue(retryButton.waitForExistence(timeout: Constants.timeout * 2))
+
+        while !retryButton.isHittable {
+            table.swipeUp()
+        }
+
+        retryButton.tap()
 
         while table.cells.count <= pageSize {
             table.swipeUp()

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/PaginatablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/PaginatablePluginExampleUITest.swift
@@ -46,8 +46,9 @@ final class PaginatablePluginExampleUITest: BaseUITestCase {
         XCTAssertTrue(cell.label.contains("page 1"))
     }
 
-    func testTable_whenSwipeUp_thenHittableActivityIndicator() {
+    func testTable_whenSwipeUp_thenPaginatorErrorAppear_thenHittableActivityIndicator() {
         let activityIndicator = app.activityIndicators["PaginatorView"]
+        let retryButton = app.buttons["Retry"]
 
         setTab("Table")
         tapTableElement("Table with pagination")
@@ -55,9 +56,15 @@ final class PaginatablePluginExampleUITest: BaseUITestCase {
         let table = app.tables.firstMatch
         XCTAssertTrue(table.waitForExistence(timeout: Constants.timeout))
 
-        while !activityIndicator.isHittable {
+        XCTAssertTrue(retryButton.waitForExistence(timeout: Constants.timeout * 2))
+
+        while !retryButton.isHittable {
             table.swipeUp()
         }
+
+        XCTAssertFalse(activityIndicator.isHittable)
+
+        retryButton.tap()
 
         XCTAssertTrue(activityIndicator.isHittable)
     }

--- a/Source/Collection/Plugins/PluginAction/CollectionPaginatablePlugin.swift
+++ b/Source/Collection/Plugins/PluginAction/CollectionPaginatablePlugin.swift
@@ -101,6 +101,10 @@ extension CollectionPaginatablePlugin: PaginatableInput {
         progressView.showProgress(isLoading)
     }
 
+    public func updateError(_ error: Error?) {
+        progressView.showError(error)
+    }
+
     public func updatePagination(canIterate: Bool) {
         self.canIterate = canIterate
     }

--- a/Source/Table/Plugins/PluginAction/TablePaginatablePlugin.swift
+++ b/Source/Table/Plugins/PluginAction/TablePaginatablePlugin.swift
@@ -82,7 +82,7 @@ public class TablePaginatablePlugin: BaseTablePlugin<TableEvent> {
     private let progressView: ProgressView
     private weak var output: PaginatableOutput?
 
-    private var isLoading: Bool
+    private var isLoading: Bool = false
 
     private weak var tableView: UITableView?
 

--- a/Source/Table/Plugins/PluginAction/TablePaginatablePlugin.swift
+++ b/Source/Table/Plugins/PluginAction/TablePaginatablePlugin.swift
@@ -82,6 +82,8 @@ public class TablePaginatablePlugin: BaseTablePlugin<TableEvent> {
     private let progressView: ProgressView
     private weak var output: PaginatableOutput?
 
+    private var isLoading: Bool = false
+
     private weak var tableView: UITableView?
 
     /// Property which indicating availability of pages
@@ -129,7 +131,7 @@ public class TablePaginatablePlugin: BaseTablePlugin<TableEvent> {
             let lastCellInLastSectionIndex = generators[lastSectionIndex].count - 1
 
             let lastCellIndexPath = IndexPath(row: lastCellInLastSectionIndex, section: lastSectionIndex)
-            if indexPath == lastCellIndexPath && canIterate {
+            if indexPath == lastCellIndexPath && canIterate && !isLoading {
                 output?.loadNextPage(with: self)
             }
         default:
@@ -144,6 +146,7 @@ public class TablePaginatablePlugin: BaseTablePlugin<TableEvent> {
 extension TablePaginatablePlugin: PaginatableInput {
 
     public func updateProgress(isLoading: Bool) {
+        self.isLoading = isLoading
         progressView.showProgress(isLoading)
     }
 

--- a/Source/Table/Plugins/PluginAction/TablePaginatablePlugin.swift
+++ b/Source/Table/Plugins/PluginAction/TablePaginatablePlugin.swift
@@ -82,7 +82,7 @@ public class TablePaginatablePlugin: BaseTablePlugin<TableEvent> {
     private let progressView: ProgressView
     private weak var output: PaginatableOutput?
 
-    private var isLoading: Bool = false
+    private var isLoading: Bool
 
     private weak var tableView: UITableView?
 


### PR DESCRIPTION
## Что сделано?

- Расширен протокол `ProgressDisplayableItem`
- Расширен протокол `PaginatableInput`
- Обновлен пример использования плагина paginatable 
- ...

## Зачем это сделано?

Чтобы при ошибках загрузки страницы можно было визуализировать ошибку на месте футера и вызвать повтор.

## На что обратить внимание?

- ~~UI тесты скорее всего сломаются. Надо будет адаптировать.~~ Done
- Реализация для коллекции будет после утверждения подхода.
- ...

## Как протестировать?

- Тапнуть в примере на строчку "Table with pagination". Первая попытка загрузки следующей странички всегда с ошибкой.

https://user-images.githubusercontent.com/28707156/227989592-8867c694-e150-4544-9d31-2eb6859ba653.mp4

