### PR TITLE
Feature/paginatable collection with error

### DIFF
--- a/Example/ReactiveDataDisplayManager/Collection/PaginatableCollectionViewController/PaginatableCollectionViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Collection/PaginatableCollectionViewController/PaginatableCollectionViewController.swift
@@ -33,6 +33,7 @@ final class PaginatableCollectionViewController: UIViewController {
 
     private weak var paginatableInput: PaginatableInput?
 
+    private var isFirstPageLoading = true
     private var currentPage = 0
 
     // MARK: - UIViewController
@@ -102,6 +103,15 @@ private extension PaginatableCollectionViewController {
         return TitleCollectionViewCell.rddm.baseGenerator(with: title)
     }
 
+    func canFillNext() -> Bool {
+        if isFirstPageLoading {
+            isFirstPageLoading.toggle()
+            return false
+        } else {
+            return true
+        }
+    }
+
     func fillNext() -> Bool {
         currentPage += 1
 
@@ -136,10 +146,16 @@ extension PaginatableCollectionViewController: PaginatableOutput {
         input.updateProgress(isLoading: true)
 
         delay(.now() + .seconds(3)) { [weak self, weak input] in
-            let canIterate = self?.fillNext() ?? false
+            let canFillNext = self?.canFillNext() ?? false
+            if canFillNext {
+                let canIterate = self?.fillNext() ?? false
 
-            input?.updateProgress(isLoading: false)
-            input?.updatePagination(canIterate: canIterate)
+                input?.updateProgress(isLoading: false)
+                input?.updatePagination(canIterate: canIterate)
+            } else {
+                input?.updateProgress(isLoading: false)
+                input?.updateError(SampleError.sample)
+            }
         }
     }
 

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/PaginatablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/PaginatablePluginExampleUITest.swift
@@ -15,7 +15,7 @@ final class PaginatablePluginExampleUITest: BaseUITestCase {
 
     // Description: The first cell of the table is always the same
     func testTable_whenSwipeUp_thenCellsCountChanged() throws {
-        let pageSize = 17
+        let pageSize = 16
 
         setTab("Table")
         tapTableElement("Table with pagination")
@@ -27,13 +27,13 @@ final class PaginatablePluginExampleUITest: BaseUITestCase {
         XCTAssertTrue(retryButton.waitForExistence(timeout: Constants.timeout * 2))
 
         while !retryButton.isHittable {
-            table.swipeUp()
+            table.swipeUp(velocity: .fast)
         }
 
         retryButton.tap()
 
         while table.cells.count <= pageSize {
-            table.swipeUp()
+            table.swipeUp(velocity: .fast)
         }
 
         XCTAssertGreaterThan(table.cells.count, pageSize)
@@ -45,14 +45,21 @@ final class PaginatablePluginExampleUITest: BaseUITestCase {
         tapTableElement("Collection with pagination")
 
         let collection = app.collectionViews.firstMatch
+        let firstCell = app.collectionViews.cells.firstMatch
+        let retryButton = app.buttons["Retry"]
         XCTAssertTrue(collection.waitForExistence(timeout: Constants.timeout))
 
-        while collection.cells.firstMatch.label.contains("page 0") {
-            collection.swipeUp()
+        while !retryButton.isHittable {
+            collection.swipeUp(velocity: .fast)
         }
 
-        let cell = collection.cells.firstMatch
-        XCTAssertTrue(cell.label.contains("page 1"))
+        retryButton.tap()
+
+        while firstCell.label.hasSuffix("page 0") {
+            collection.swipeUp(velocity: .fast)
+        }
+
+        XCTAssertTrue(firstCell.label.hasSuffix("page 1"))
     }
 
     func testTable_whenSwipeUp_thenPaginatorErrorAppear_thenHittableActivityIndicator() {
@@ -68,7 +75,7 @@ final class PaginatablePluginExampleUITest: BaseUITestCase {
         XCTAssertTrue(retryButton.waitForExistence(timeout: Constants.timeout * 2))
 
         while !retryButton.isHittable {
-            table.swipeUp()
+            table.swipeUp(velocity: .fast)
         }
 
         XCTAssertFalse(activityIndicator.isHittable)
@@ -80,6 +87,7 @@ final class PaginatablePluginExampleUITest: BaseUITestCase {
 
     func testCollection_whenSwipeUp_thenHittableActivityIndicator() {
         let activityIndicator = app.activityIndicators["PaginatorView"]
+        let retryButton = app.buttons["Retry"]
 
         setTab("Collection")
         tapTableElement("Collection with pagination")
@@ -87,9 +95,13 @@ final class PaginatablePluginExampleUITest: BaseUITestCase {
         let collection = app.collectionViews.firstMatch
         XCTAssertTrue(collection.waitForExistence(timeout: Constants.timeout))
 
-        while !activityIndicator.isHittable {
-            collection.swipeUp()
+        while !retryButton.isHittable {
+            collection.swipeUp(velocity: .fast)
         }
+
+        XCTAssertFalse(activityIndicator.isHittable)
+
+        retryButton.tap()
 
         XCTAssertTrue(activityIndicator.isHittable)
     }

--- a/Source/Collection/Plugins/PluginAction/CollectionPaginatablePlugin.swift
+++ b/Source/Collection/Plugins/PluginAction/CollectionPaginatablePlugin.swift
@@ -25,6 +25,8 @@ public class CollectionPaginatablePlugin: BaseCollectionPlugin<CollectionEvent> 
     private let progressView: ProgressView
     private weak var output: PaginatableOutput?
 
+    private var isLoading: Bool = false
+
     private weak var collectionView: UICollectionView?
 
     /// Property which indicating availability of pages
@@ -63,6 +65,12 @@ public class CollectionPaginatablePlugin: BaseCollectionPlugin<CollectionEvent> 
         collectionView = manager?.view
         canIterate = false
         output?.onPaginationInitialized(with: self)
+        self.progressView.setOnRetry { [weak self] in
+            guard let input = self, let output = self?.output else {
+                return
+            }
+            output.loadNextPage(with: input)
+        }
     }
 
     public override func process(event: CollectionEvent, with manager: BaseCollectionManager?) {
@@ -76,7 +84,7 @@ public class CollectionPaginatablePlugin: BaseCollectionPlugin<CollectionEvent> 
             let lastCellInLastSectionIndex = generators[lastSectionIndex].count - 1
 
             let lastCellIndexPath = IndexPath(row: lastCellInLastSectionIndex, section: lastSectionIndex)
-            guard indexPath == lastCellIndexPath, canIterate else {
+            guard indexPath == lastCellIndexPath, canIterate, !isLoading else {
                 return
             }
 
@@ -98,6 +106,7 @@ public class CollectionPaginatablePlugin: BaseCollectionPlugin<CollectionEvent> 
 extension CollectionPaginatablePlugin: PaginatableInput {
 
     public func updateProgress(isLoading: Bool) {
+        self.isLoading = isLoading
         progressView.showProgress(isLoading)
     }
 


### PR DESCRIPTION
## Что сделано?

- Добавлена возможность отображения ErrorState в плагине Paginatable
- ...

## Зачем это сделано?

Чтобы при ошибках загрузки страницы можно было визуализировать ошибку на месте футера и вызвать повтор.

## На что обратить внимание?
- Рекомендуется проверить на реальной верстке (например в шаблонах) чтобы исключить/отладить проблемы с изменением фрейма во время переходов между loading и error стейтами.

## Как протестировать?

- Тапнуть в примере на строчку "Collection with pagination"
