### PR TITLE
add safe animator checking if number of generators are equal to numbe…

### DIFF
--- a/ReactiveDataDisplayManagerTests/Builder/Collection/Stubs/CollectionAnimatorStub.swift
+++ b/ReactiveDataDisplayManagerTests/Builder/Collection/Stubs/CollectionAnimatorStub.swift
@@ -17,10 +17,10 @@ final class CollectionAnimatorStub: Animator<BaseCollectionManager.CollectionTyp
 
     // MARK: - Animator
 
-    override func perform(in collection: BaseCollectionManager.CollectionType, animated: Bool, operation: () -> Void) {
+    override func perform(in collection: BaseCollectionManager.CollectionType, animated: Bool, operation: Operation?) {
         generatorsUpdated = true
     }
 
-    override func performAnimated(in collection: BaseCollectionManager.CollectionType, operation: () -> Void) { }
+    override func performAnimated(in collection: BaseCollectionManager.CollectionType, operation: Operation?) { }
 
 }

--- a/ReactiveDataDisplayManagerTests/Builder/Table/Stubs/TableAnimatorStub.swift
+++ b/ReactiveDataDisplayManagerTests/Builder/Table/Stubs/TableAnimatorStub.swift
@@ -17,10 +17,10 @@ final class TableAnimatorStub: Animator<BaseTableManager.CollectionType> {
 
     // MARK: - Animator
 
-    override func perform(in collection: BaseTableManager.CollectionType, animated: Bool, operation: () -> Void) {
+    override func perform(in collection: BaseTableManager.CollectionType, animated: Bool, operation: Operation?) {
         generatorsUpdated = true
     }
 
-    override func performAnimated(in collection: BaseTableManager.CollectionType, operation: () -> Void) { }
+    override func performAnimated(in collection: BaseTableManager.CollectionType, operation: Operation?) { }
 
 }

--- a/Source/Collection/Animator/CollectionBatchUpdatesAnimator.swift
+++ b/Source/Collection/Animator/CollectionBatchUpdatesAnimator.swift
@@ -11,8 +11,8 @@ import UIKit
 /// UICollectionView Animator based on performBatchUpdates
 public class CollectionBatchUpdatesAnimator: Animator<UICollectionView> {
 
-    public override func performAnimated(in collection: UICollectionView, operation: () -> Void) {
-        collection.performBatchUpdates(operation)
+    public override func performAnimated(in collection: UICollectionView, operation: Operation?) {
+        collection.performBatchUpdates(operation ?? {})
     }
 
 }

--- a/Source/Collection/Animator/CollectionBatchUpdatesAnimator.swift
+++ b/Source/Collection/Animator/CollectionBatchUpdatesAnimator.swift
@@ -12,7 +12,7 @@ import UIKit
 public class CollectionBatchUpdatesAnimator: Animator<UICollectionView> {
 
     public override func performAnimated(in collection: UICollectionView, operation: Operation?) {
-        collection.performBatchUpdates(operation ?? {})
+        collection.performBatchUpdates(operation ?? { })
     }
 
 }

--- a/Source/Collection/Animator/CollectionSafeAnimator.swift
+++ b/Source/Collection/Animator/CollectionSafeAnimator.swift
@@ -1,0 +1,38 @@
+//
+//  CollectionSafeAnimator.swift
+//  ReactiveDataDisplayManager
+//
+//  Created by Никита Коробейников on 18.05.2023.
+//
+
+import UIKit
+
+/// UITableView Animator wrapper created to avoid crashing on empty operation in parallel with updates of data source
+public class CollectionSafeAnimator: Animator<UICollectionView> {
+
+    private let baseAnimator: Animator<UICollectionView>
+    private weak var generatorsProvider: CollectionGeneratorsProvider?
+
+    public init(baseAnimator: Animator<UICollectionView>, generatorsProvider: CollectionGeneratorsProvider?) {
+        self.baseAnimator = baseAnimator
+        self.generatorsProvider = generatorsProvider
+    }
+
+    public override func performAnimated(in collection: UICollectionView, operation: Operation?) {
+        if (operation == nil) {
+            let numberOfSectionsAreEqual = collection.numberOfSections == generatorsProvider?.sections.count
+            guard numberOfSectionsAreEqual else {
+                return
+            }
+            let numberOfCellsAreEqual = (0...(collection.numberOfSections - 1))
+                .map { generatorsProvider?.generators[$0].count == collection.numberOfItems(inSection: $0) }
+                .allSatisfy { $0 == true }
+
+            guard numberOfCellsAreEqual else {
+                return
+            }
+        }
+        baseAnimator.performAnimated(in: collection, operation: operation)
+    }
+
+}

--- a/Source/Collection/Animator/CollectionSafeAnimator.swift
+++ b/Source/Collection/Animator/CollectionSafeAnimator.swift
@@ -7,8 +7,8 @@
 
 import UIKit
 
-/// UITableView Animator wrapper created to avoid crashing on empty operation in parallel with updates of data source
-public class CollectionSafeAnimator: Animator<UICollectionView> {
+/// UICollectionView Animator wrapper created to avoid crashing on empty operation in parallel with updates of data source
+public final class CollectionSafeAnimator: Animator<UICollectionView> {
 
     private let baseAnimator: Animator<UICollectionView>
     private weak var generatorsProvider: CollectionGeneratorsProvider?
@@ -19,7 +19,7 @@ public class CollectionSafeAnimator: Animator<UICollectionView> {
     }
 
     public override func performAnimated(in collection: UICollectionView, operation: Operation?) {
-        if (operation == nil) {
+        if operation == nil {
             let numberOfSectionsAreEqual = collection.numberOfSections == generatorsProvider?.sections.count
             guard numberOfSectionsAreEqual else {
                 return

--- a/Source/Collection/DataSource/BaseCollectionDataSource.swift
+++ b/Source/Collection/DataSource/BaseCollectionDataSource.swift
@@ -39,7 +39,7 @@ extension BaseCollectionDataSource {
 
         modifier = CollectionCommonModifier(view: builder.view, animator: builder.animator)
 
-        animator = builder.animator
+        animator = CollectionSafeAnimator(baseAnimator: builder.animator, generatorsProvider: builder.manager)
         movablePlugin = builder.movablePlugin?.dataSource
         collectionPlugins = builder.collectionPlugins
         itemTitleDisplayablePlugin = builder.itemTitleDisplayablePlugin
@@ -147,23 +147,11 @@ private extension BaseCollectionDataSource {
             return
         }
         expandable.onHeightChanged += { [weak self, weak collectionView] _ in
-            guard let collectionView = collectionView, self?.checkIfNumberOfCellsMatches(for: collectionView) == true else {
+            guard let collectionView = collectionView else {
                 return
             }
-            self?.animator?.perform(in: collectionView, animated: true) { }
+            self?.animator?.perform(in: collectionView, animated: true, operation: nil)
         }
-    }
-
-    func checkIfNumberOfCellsMatches(for collectionView: UICollectionView) -> Bool {
-        let numberOfSectionsAreEqual = collectionView.numberOfSections == provider?.sections.count
-        guard numberOfSectionsAreEqual else {
-            return false
-        }
-        let numberOfCellsAreEqual = (0...(collectionView.numberOfSections - 1))
-            .map { provider?.generators[$0].count == collectionView.numberOfItems(inSection: $0) }
-            .allSatisfy { $0 == true }
-
-        return numberOfCellsAreEqual
     }
 
 }

--- a/Source/Protocols/Animator/Animator.swift
+++ b/Source/Protocols/Animator/Animator.swift
@@ -11,12 +11,14 @@ import UIKit
 /// Entity to animate specific collection operations like insert or remove rows
 open class Animator<Collection: UIView> {
 
+    public typealias Operation = () -> Void
+
     /// Perform animation block.
     /// For example. Insert, or delete rows of collecton
     /// - parameter collection: Collection containing animating rows
     /// - parameter animated: Should execute operation animated?
     /// - parameter operation: Operation block. Might be any operation with collection.
-    func perform(in collection: Collection, animated: Bool, operation: () -> Void) {
+    func perform(in collection: Collection, animated: Bool, operation: Operation?) {
         if animated {
             performAnimated(in: collection, operation: operation)
         } else {
@@ -30,7 +32,7 @@ open class Animator<Collection: UIView> {
     /// For example. Insert, or delete rows of collecton
     /// - parameter collection: Collection containing animating row
     /// - parameter operation: Operation block. Might be any operation with collection.
-    func performAnimated(in collection: Collection, operation: () -> Void) {
+    func performAnimated(in collection: Collection, operation: Operation?) {
         preconditionFailure("\(#function) must be overriden in child")
     }
 

--- a/Source/Table/Animator/TableBatchUpdatesAnimator.swift
+++ b/Source/Table/Animator/TableBatchUpdatesAnimator.swift
@@ -13,7 +13,7 @@ import UIKit
 public class TableBatchUpdatesAnimator: Animator<UITableView> {
 
     public override func performAnimated(in collection: UITableView, operation: Operation?) {
-        collection.performBatchUpdates(operation ?? {})
+        collection.performBatchUpdates(operation ?? { })
     }
 
 }

--- a/Source/Table/Animator/TableBatchUpdatesAnimator.swift
+++ b/Source/Table/Animator/TableBatchUpdatesAnimator.swift
@@ -12,8 +12,8 @@ import UIKit
 @available(iOS 11.0, tvOS 11.0, *)
 public class TableBatchUpdatesAnimator: Animator<UITableView> {
 
-    public override func performAnimated(in collection: UITableView, operation: () -> Void) {
-        collection.performBatchUpdates(operation)
+    public override func performAnimated(in collection: UITableView, operation: Operation?) {
+        collection.performBatchUpdates(operation ?? {})
     }
 
 }

--- a/Source/Table/Animator/TableSafeAnimator.swift
+++ b/Source/Table/Animator/TableSafeAnimator.swift
@@ -1,0 +1,38 @@
+//
+//  TableSafeAnimator.swift
+//  ReactiveDataDisplayManager
+//
+//  Created by Никита Коробейников on 18.05.2023.
+//
+
+import UIKit
+
+/// UITableView Animator wrapper created to avoid crashing on empty operation in parallel with updates of data source
+public class TableSafeAnimator: Animator<UITableView> {
+
+    private let baseAnimator: Animator<UITableView>
+    private weak var generatorsProvider: TableGeneratorsProvider?
+
+    public init(baseAnimator: Animator<UITableView>, generatorsProvider: TableGeneratorsProvider?) {
+        self.baseAnimator = baseAnimator
+        self.generatorsProvider = generatorsProvider
+    }
+
+    public override func performAnimated(in collection: UITableView, operation: Operation?) {
+        if (operation == nil) {
+            let numberOfSectionsAreEqual = collection.numberOfSections == generatorsProvider?.sections.count
+            guard numberOfSectionsAreEqual else {
+                return
+            }
+            let numberOfCellsAreEqual = (0...(collection.numberOfSections - 1))
+                .map { generatorsProvider?.generators[$0].count == collection.numberOfRows(inSection: $0) }
+                .allSatisfy { $0 == true }
+
+            guard numberOfCellsAreEqual else {
+                return
+            }
+        }
+        baseAnimator.performAnimated(in: collection, operation: operation)
+    }
+
+}

--- a/Source/Table/Animator/TableSafeAnimator.swift
+++ b/Source/Table/Animator/TableSafeAnimator.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 /// UITableView Animator wrapper created to avoid crashing on empty operation in parallel with updates of data source
-public class TableSafeAnimator: Animator<UITableView> {
+public final class TableSafeAnimator: Animator<UITableView> {
 
     private let baseAnimator: Animator<UITableView>
     private weak var generatorsProvider: TableGeneratorsProvider?
@@ -19,7 +19,7 @@ public class TableSafeAnimator: Animator<UITableView> {
     }
 
     public override func performAnimated(in collection: UITableView, operation: Operation?) {
-        if (operation == nil) {
+        if operation == nil {
             let numberOfSectionsAreEqual = collection.numberOfSections == generatorsProvider?.sections.count
             guard numberOfSectionsAreEqual else {
                 return

--- a/Source/Table/Animator/TableUpdatesAnimator.swift
+++ b/Source/Table/Animator/TableUpdatesAnimator.swift
@@ -11,9 +11,9 @@ import UIKit
 /// UITableView Animator based on beginUpdates and endUpdates
 public class TableUpdatesAnimator: Animator<UITableView> {
 
-    public override func performAnimated(in collection: UITableView, operation: () -> Void) {
+    public override func performAnimated(in collection: UITableView, operation: Operation?) {
         collection.beginUpdates()
-        operation()
+        operation?()
         collection.endUpdates()
     }
 

--- a/Source/Table/DataSource/BaseTableDataSource.swift
+++ b/Source/Table/DataSource/BaseTableDataSource.swift
@@ -41,7 +41,7 @@ extension BaseTableDataSource {
 
         modifier = TableCommonModifier(view: builder.view, animator: builder.animator)
 
-        animator = builder.animator
+        animator = TableSafeAnimator(baseAnimator: builder.animator, generatorsProvider: builder.manager)
         movablePlugin = builder.movablePlugin?.dataSource
         sectionTitleDisplayablePlugin = builder.sectionTitleDisplayablePlugin
         tablePlugins = builder.tablePlugins
@@ -126,23 +126,11 @@ private extension BaseTableDataSource {
             return
         }
         expandable.onHeightChanged += { [weak self, weak tableView] _ in
-            guard let tableView = tableView, self?.checkIfNumberOfCellsMatches(for: tableView) == true else {
+            guard let tableView = tableView else {
                 return
             }
-            self?.animator?.perform(in: tableView, animated: expandable.animatedExpandable) { }
+            self?.animator?.perform(in: tableView, animated: expandable.animatedExpandable, operation: nil)
         }
-    }
-
-    func checkIfNumberOfCellsMatches(for tableView: UITableView) -> Bool {
-        let numberOfSectionsAreEqual = tableView.numberOfSections == provider?.sections.count
-        guard numberOfSectionsAreEqual else {
-            return false
-        }
-        let numberOfCellsAreEqual = (0...(tableView.numberOfSections - 1))
-            .map { provider?.generators[$0].count == tableView.numberOfRows(inSection: $0) }
-            .allSatisfy { $0 == true }
-
-        return numberOfCellsAreEqual
     }
 
 }


### PR DESCRIPTION
## Что сделано?

- Созданы *SafeAnimator's с проверкой на равенство количества генераторов ячеек и фактических ячеек 
- ...

## Зачем это сделано?

Чтобы в библиотеке было унифицированное решение исключающее ошибку в будущих плагинах.

## На что обратить внимание?

- Надо найти еще места где в аниматор передавался пустая операция
- Проблематично 
- Желательно таки добавить UI stress-test на отсутствие краша при поступлении апдейтов во время Animator.perform с пустой операцией
- ...

## Как протестировать?

- Тапнуть в примере на строчку Table with all plugins 
- Проверить работу Expandable ячейки
