### PR TITLE
Feature/spt 1461/image placeholders for example

### DIFF
--- a/Example/Common/ImageUrlProvider.swift
+++ b/Example/Common/ImageUrlProvider.swift
@@ -1,8 +1,8 @@
 //
 //  ImageUrlProvider.swift
-//  ReactiveDataDisplayManager
+//  ReactiveDataDisplayManagerExample_tvOS
 //
-//  Created by Никита Коробейников on 23.05.2023.
+//  Created by Никита Коробейников on 24.05.2023.
 //
 
 import Foundation

--- a/Example/ReactiveDataDisplayManager/Collection/Views/Cells/ImageCollectionViewCell/ImageCollectionViewCell.swift
+++ b/Example/ReactiveDataDisplayManager/Collection/Views/Cells/ImageCollectionViewCell/ImageCollectionViewCell.swift
@@ -19,7 +19,7 @@ final class ImageCollectionViewCell: UICollectionViewCell {
         let loadImage: (URL, UIImageView) -> Void
 
         static func make(with loadImage: @escaping (URL, UIImageView) -> Void) -> Self? {
-            let stringImageUrl = "https://loremflickr.com/640/480/cat"
+            let stringImageUrl = ImageUrlProvider.getRandomImage(of: .init(width: 640, height: 480))
             guard let imageUrl = URL(string: stringImageUrl) else { return nil }
             return .init(imageUrl: imageUrl, loadImage: loadImage)
         }

--- a/Example/ReactiveDataDisplayManager/Collection/Views/Cells/ImageCollectionViewCell/ImageCollectionViewCell.swift
+++ b/Example/ReactiveDataDisplayManager/Collection/Views/Cells/ImageCollectionViewCell/ImageCollectionViewCell.swift
@@ -19,7 +19,7 @@ final class ImageCollectionViewCell: UICollectionViewCell {
         let loadImage: (URL, UIImageView) -> Void
 
         static func make(with loadImage: @escaping (URL, UIImageView) -> Void) -> Self? {
-            let stringImageUrl = "https://picsum.photos/id/\(Int.random(in: 0...1000))/640/480"
+            let stringImageUrl = "https://loremflickr.com/640/480/cat"
             guard let imageUrl = URL(string: stringImageUrl) else { return nil }
             return .init(imageUrl: imageUrl, loadImage: loadImage)
         }

--- a/Example/ReactiveDataDisplayManager/Table/Views/Cells/ImageTableViewCell/ImageTableViewCell.swift
+++ b/Example/ReactiveDataDisplayManager/Table/Views/Cells/ImageTableViewCell/ImageTableViewCell.swift
@@ -20,7 +20,7 @@ final class ImageTableViewCell: UITableViewCell {
         let loadImage: (URL, UIImageView) -> Void
 
         static func make(with loadImage: @escaping (URL, UIImageView) -> Void) -> Self? {
-            let stringImageUrl = "https://loremflickr.com/1280/720/cat"
+            let stringImageUrl = ImageUrlProvider.getRandomImage(of: .init(width: 1280, height: 720))
             guard let imageUrl = URL(string: stringImageUrl) else { return nil }
             return .init(imageUrl: imageUrl, title: stringImageUrl, loadImage: loadImage)
         }

--- a/Example/ReactiveDataDisplayManager/Table/Views/Cells/ImageTableViewCell/ImageTableViewCell.swift
+++ b/Example/ReactiveDataDisplayManager/Table/Views/Cells/ImageTableViewCell/ImageTableViewCell.swift
@@ -20,7 +20,7 @@ final class ImageTableViewCell: UITableViewCell {
         let loadImage: (URL, UIImageView) -> Void
 
         static func make(with loadImage: @escaping (URL, UIImageView) -> Void) -> Self? {
-            let stringImageUrl = "https://picsum.photos/id/\(Int.random(in: 0...1000))/1280/720"
+            let stringImageUrl = "https://loremflickr.com/1280/720/cat"
             guard let imageUrl = URL(string: stringImageUrl) else { return nil }
             return .init(imageUrl: imageUrl, title: stringImageUrl, loadImage: loadImage)
         }

--- a/Example/ReactiveDataDisplayManager/Utils/ImageUrlProvider.swift
+++ b/Example/ReactiveDataDisplayManager/Utils/ImageUrlProvider.swift
@@ -1,0 +1,22 @@
+//
+//  ImageUrlProvider.swift
+//  ReactiveDataDisplayManager
+//
+//  Created by Никита Коробейников on 23.05.2023.
+//
+
+import Foundation
+import UIKit
+
+enum ImageUrlProvider {
+
+    private static let allKeywords = ["cat", "dog", "man", "women", "tree", "money", "fun", "forest", "nature", "beach", "sun"]
+
+    static func getRandomImage(of size: CGSize) -> String {
+        let keyword = allKeywords.randomElement() ?? "cat"
+        return "https://loremflickr.com/\(Int(size.width))/\(Int(size.height))/\(keyword)"
+    }
+
+}
+
+

--- a/Example/ReactiveDataDisplayManager/Utils/ImageUrlProvider.swift
+++ b/Example/ReactiveDataDisplayManager/Utils/ImageUrlProvider.swift
@@ -18,5 +18,3 @@ enum ImageUrlProvider {
     }
 
 }
-
-

--- a/Example/ReactiveDataDisplayManagerExampleTv/Views/Cells/ImageViewModel.swift
+++ b/Example/ReactiveDataDisplayManagerExampleTv/Views/Cells/ImageViewModel.swift
@@ -12,7 +12,7 @@ struct ImageViewModel {
     let loadImage: (URL, UIImageView) -> Void
 
     static func make(with loadImage: @escaping (URL, UIImageView) -> Void) -> Self? {
-        let stringImageUrl = "https://picsum.photos/id/\(Int.random(in: 0...1000))/640/480"
+        let stringImageUrl = "https://loremflickr.com/640/480/cat"
         guard let imageUrl = URL(string: stringImageUrl) else { return nil }
         return .init(imageUrl: imageUrl, loadImage: loadImage)
     }

--- a/Example/ReactiveDataDisplayManagerExampleTv/Views/Cells/ImageViewModel.swift
+++ b/Example/ReactiveDataDisplayManagerExampleTv/Views/Cells/ImageViewModel.swift
@@ -12,7 +12,7 @@ struct ImageViewModel {
     let loadImage: (URL, UIImageView) -> Void
 
     static func make(with loadImage: @escaping (URL, UIImageView) -> Void) -> Self? {
-        let stringImageUrl = "https://loremflickr.com/640/480/cat"
+        let stringImageUrl = ImageUrlProvider.getRandomImage(of: .init(width: 640, height: 480))
         guard let imageUrl = URL(string: stringImageUrl) else { return nil }
         return .init(imageUrl: imageUrl, loadImage: loadImage)
     }

--- a/Example/targets/template.yml
+++ b/Example/targets/template.yml
@@ -11,6 +11,8 @@ targetTemplates:
         gatherCoverageData: true
       dependencies:
         - sdk: UIKit.framework
+      sources:
+        - path: ../Common
       info:
         properties:
           UIUserInterfaceStyle: Light


### PR DESCRIPTION
## Что сделано?

- Добавлен ImageUrlProvider для картинок с https://loremflickr.com/ в качестве источника
- ...

## Зачем это сделано?

Чтобы оживить экраны примера где раньше были картинки с picsum

## На что обратить внимание?

- Nuke кэширует картинки по пути, поэтому встречаются повторы. Чем больше будет облако ключей, тем меньше будет повторов. (Во всяком случае так лучше чем с серыми квадратиками)
- ...

## Как протестировать?

- Тапнуть в примере на строчку "Collection with compositional layout" или найти другой пример контроллера с картинками



Uploading Simulator Screen Recording - iPhone 14 Pro - 2023-05-23 at 18.15.24.mp4…
