### PR TITLE
Update gems on arm64

### DIFF
--- a/Brewfile.lock.json
+++ b/Brewfile.lock.json
@@ -2,16 +2,16 @@
   "entries": {
     "tap": {
       "homebrew/cask": {
-        "revision": "3ece2c193e9019ec49037b8f829ab42d88ece146"
+        "revision": "266747f8b172dd47e6c80ce2590889a8a7c96501"
       },
       "yonaskolb/xcodegen": {
-        "revision": "3327c44ad74c1e04e0de1e8ecca0d7114a613765",
+        "revision": "372f20fe5a3823dc398f52cb6cc1af5003d452f7",
         "options": {
           "clone_target": "https://github.com/yonaskolb/XcodeGen.git"
         }
       },
       "krzysztofzablocki/sourcery": {
-        "revision": "3a9e5f1014ac09b30727c01d2a0e1531dac30948",
+        "revision": "cc4252f1d62f7c44e5c757417a45ee0f56c889d2",
         "options": {
           "clone_target": "https://github.com/krzysztofzablocki/Sourcery.git"
         }
@@ -19,69 +19,69 @@
     },
     "brew": {
       "xcodegen": {
-        "version": "2.33.0",
+        "version": "2.25.0",
         "bottle": {
           "rebuild": 0,
           "root_url": "https://ghcr.io/v2/homebrew/core",
           "files": {
             "arm64_ventura": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:76d47e558129e02cb16dbcdbb92b25ac5ab47658f4736cd1f68d205bebcd0001",
-              "sha256": "76d47e558129e02cb16dbcdbb92b25ac5ab47658f4736cd1f68d205bebcd0001"
+              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:ca9aa5cf7c7a4573bd3ff2c1afbe871566e57478c09967abca7585fc1c237470",
+              "sha256": "ca9aa5cf7c7a4573bd3ff2c1afbe871566e57478c09967abca7585fc1c237470"
             },
             "arm64_monterey": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:092164ce460d49adbc33023f55ec6b9a5704d787e18c05ac7d62232c47bdc91e",
-              "sha256": "092164ce460d49adbc33023f55ec6b9a5704d787e18c05ac7d62232c47bdc91e"
+              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:dadb3716295017a392da394eb0bb52360d95e9142e21ac5532e1d29def593ad6",
+              "sha256": "dadb3716295017a392da394eb0bb52360d95e9142e21ac5532e1d29def593ad6"
             },
             "arm64_big_sur": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:b4ba5b91c37a2b3b364a5af35d207eac215a2c00987d008a3002a9d643d39652",
-              "sha256": "b4ba5b91c37a2b3b364a5af35d207eac215a2c00987d008a3002a9d643d39652"
+              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:6026a0e84873586f7e65584bd3e9a9456f4b590c2498ebf986e563d66bccb3a7",
+              "sha256": "6026a0e84873586f7e65584bd3e9a9456f4b590c2498ebf986e563d66bccb3a7"
             },
             "ventura": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:38a9e261286f6f7e402eef108a6b0fc02884a9872d9464d69a56b1adc725c7fe",
-              "sha256": "38a9e261286f6f7e402eef108a6b0fc02884a9872d9464d69a56b1adc725c7fe"
+              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:bb982470aad36dececfab94449696b1a327ea931b61475832fd41c5fa59ebb60",
+              "sha256": "bb982470aad36dececfab94449696b1a327ea931b61475832fd41c5fa59ebb60"
             },
             "monterey": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:a05217b82deaa2efa0ee832b663232aab66aabe2d2c08ad2e3fde723b6faffb0",
-              "sha256": "a05217b82deaa2efa0ee832b663232aab66aabe2d2c08ad2e3fde723b6faffb0"
+              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:366403595292790a4a84e2db6f0f32c14fa907c77ac424a5e24d431d372e7a17",
+              "sha256": "366403595292790a4a84e2db6f0f32c14fa907c77ac424a5e24d431d372e7a17"
             },
             "big_sur": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:f5b9313d25bff493ea073b291c2a86d3633cc16ec331fa3d2caf8a1131247bbb",
-              "sha256": "f5b9313d25bff493ea073b291c2a86d3633cc16ec331fa3d2caf8a1131247bbb"
+              "url": "https://ghcr.io/v2/homebrew/core/xcodegen/blobs/sha256:6db46a3673d4cd395cabd22bbe28e701eef7eaa4f198829fd8a4df072eb9a6ff",
+              "sha256": "6db46a3673d4cd395cabd22bbe28e701eef7eaa4f198829fd8a4df072eb9a6ff"
             }
           }
         }
       },
       "sourcery": {
-        "version": "1.9.2",
+        "version": "1.8.1",
         "bottle": {
           "rebuild": 0,
           "root_url": "https://ghcr.io/v2/homebrew/core",
           "files": {
             "arm64_ventura": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/sourcery/blobs/sha256:37f85dd2fc0091ba35abf1bc059ac2ab9eb7490955b327445f52d5c92a26fd44",
-              "sha256": "37f85dd2fc0091ba35abf1bc059ac2ab9eb7490955b327445f52d5c92a26fd44"
+              "url": "https://ghcr.io/v2/homebrew/core/sourcery/blobs/sha256:bafccb509c0586fd8725582aec7c7da7fe88055c7a8608d4ca0f5803a37988fb",
+              "sha256": "bafccb509c0586fd8725582aec7c7da7fe88055c7a8608d4ca0f5803a37988fb"
             },
             "arm64_monterey": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/sourcery/blobs/sha256:5bd5a098011084a2eb0a967382a93997975535195badd3ad5807e3cd19fdcf6e",
-              "sha256": "5bd5a098011084a2eb0a967382a93997975535195badd3ad5807e3cd19fdcf6e"
+              "url": "https://ghcr.io/v2/homebrew/core/sourcery/blobs/sha256:f3d3c5407c9de6d7eb9d6dfdffa4fb01350c31d6d335bc26ff94eea7ed7e66c9",
+              "sha256": "f3d3c5407c9de6d7eb9d6dfdffa4fb01350c31d6d335bc26ff94eea7ed7e66c9"
             },
             "ventura": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/sourcery/blobs/sha256:3be6812ef327e5e0d9ba0b52c6809e89ec74a4effdcefc4968f7fbc369efcbe2",
-              "sha256": "3be6812ef327e5e0d9ba0b52c6809e89ec74a4effdcefc4968f7fbc369efcbe2"
+              "url": "https://ghcr.io/v2/homebrew/core/sourcery/blobs/sha256:9d6ed066d64296432ac9a1bc91aef8606c5d966c56f535fff011ae39fbea9746",
+              "sha256": "9d6ed066d64296432ac9a1bc91aef8606c5d966c56f535fff011ae39fbea9746"
             },
             "monterey": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/sourcery/blobs/sha256:26816c3345810c1b3e154dbdb6b273ea59ba87394dc9773092beee1d223ff0b6",
-              "sha256": "26816c3345810c1b3e154dbdb6b273ea59ba87394dc9773092beee1d223ff0b6"
+              "url": "https://ghcr.io/v2/homebrew/core/sourcery/blobs/sha256:039e1516d4cbdcb7107ac7a1777f9cb11891ef36a4b5f12ae6dd57b6157b6b3e",
+              "sha256": "039e1516d4cbdcb7107ac7a1777f9cb11891ef36a4b5f12ae6dd57b6157b6b3e"
             }
           }
         }
@@ -107,12 +107,12 @@
         "macOS": "11.5.1"
       },
       "ventura": {
-        "HOMEBREW_VERSION": "3.6.15-53-g4534748",
-        "HOMEBREW_PREFIX": "/usr/local",
-        "Homebrew/homebrew-core": "d0befea5025acac52ece7e6c67966708f025c2af",
+        "HOMEBREW_VERSION": "4.0.19",
+        "HOMEBREW_PREFIX": "/opt/homebrew",
+        "Homebrew/homebrew-core": "api",
         "CLT": "",
-        "Xcode": "14.2",
-        "macOS": "13.0.1"
+        "Xcode": "14.3",
+        "macOS": "13.4"
       }
     }
   }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.5)
+    CFPropertyList (3.0.6)
       rexml
     activesupport (6.1.7.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -9,7 +9,7 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    addressable (2.8.1)
+    addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
@@ -64,7 +64,7 @@ GEM
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
-    i18n (1.12.0)
+    i18n (1.13.0)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     minitest (5.18.0)
@@ -72,16 +72,18 @@ GEM
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
-    nokogiri (1.14.3-x86_64-darwin)
+    nokogiri (1.15.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.3-x86_64-linux)
+    nokogiri (1.15.2-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.2-x86_64-linux)
       racc (~> 1.4)
     public_suffix (4.0.7)
     racc (1.6.2)
     rexml (3.2.5)
     rouge (2.0.7)
     ruby-macho (2.5.1)
-    slather (2.7.3)
+    slather (2.7.4)
       CFPropertyList (>= 2.2, < 4)
       activesupport
       clamp (~> 1.3)
@@ -100,9 +102,10 @@ GEM
       rexml (~> 3.2.4)
     xcpretty (0.3.0)
       rouge (~> 2.0.7)
-    zeitwerk (2.6.7)
+    zeitwerk (2.6.8)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-21
   x86_64-linux
 
@@ -112,4 +115,4 @@ DEPENDENCIES
   xcpretty (~> 0.3.0)
 
 BUNDLED WITH
-   2.2.33
+   2.4.6

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ init:
 ## Regenerate Framework and Example projects
 projects:
 	xcodegen generate
+	-bundle install --path .bundle
 	-bundle exec pod install
 
 ## Build Configuration

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+source ~/.bash_profile
 make projects

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+source ~/.bash_profile
 make projects


### PR DESCRIPTION
## Что сделано?

- Выполнен make init на arm64, добавлены недостающие гемы
<img width="511" alt="image" src="https://github.com/surfstudio/ReactiveDataDisplayManager/assets/14955886/17d8081a-b412-42a1-b5e5-c2ada89f2245">

## Зачем это сделано?

- Проблемы с билдом на М1 при переключении на разные ветки
<img width="585" alt="image" src="https://github.com/surfstudio/ReactiveDataDisplayManager/assets/14955886/81e53ed5-c993-40bd-94df-7fdd2a453b55">

## На что обратить внимание?

- Изменились lock файлы
- Некоторые версии стали выше, некоторые старее
- **При переключении ветки в Fork не срабатывает хук `make projects`**. Без вызова которого проблема все равно остается 
