### PR TITLE
SPT-1511 Improve stability of UI tests

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -18,12 +18,9 @@ jobs:
     - name: Build
       run: make build_lib_iOS
     - name: Run tests
-      run: |
-        test_output=$( make test_lib_iOS )
-        if [[ echo $test_output | grep "** TEST EXECUTE FAILED **" ]]; then
-          echo "::error:: Test execute failed"
-        fi
-
+      run: make test_lib_iOS
+    - name: Check Log
+      run: make check_test_log
     - name: Prepare Report
       run: make prepare_report
     - name: Upload Coverage
@@ -46,12 +43,9 @@ jobs:
     - name: Build
       run: make build_example_iOS
     - name: Run tests
-      run: |
-        test_output=$( make test_example_iOS )
-        if [[ echo $test_output | grep "** TEST EXECUTE FAILED **" ]]; then
-          echo "::error:: Test execute failed"
-        fi
-
+      run: make test_example_iOS
+    - name: Check Log
+      run: make check_test_log
     - name: Prepare Report
       run: make prepare_example_report
     - name: Upload Coverage

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -18,7 +18,12 @@ jobs:
     - name: Build
       run: make build_lib_iOS
     - name: Run tests
-      run: make test_lib_iOS
+      run: |
+        test_output=$( make test_lib_iOS )
+        if [[ echo $test_output | grep "** TEST EXECUTE FAILED **" ]]; then
+          echo "::error:: Test execute failed"
+        fi
+
     - name: Prepare Report
       run: make prepare_report
     - name: Upload Coverage
@@ -41,7 +46,12 @@ jobs:
     - name: Build
       run: make build_example_iOS
     - name: Run tests
-      run: make test_example_iOS
+      run: |
+        test_output=$( make test_example_iOS )
+        if [[ echo $test_output | grep "** TEST EXECUTE FAILED **" ]]; then
+          echo "::error:: Test execute failed"
+        fi
+
     - name: Prepare Report
       run: make prepare_example_report
     - name: Upload Coverage

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
 
   build_iOS:
-    runs-on: macOS-12
+    runs-on: macOS-13
     steps:
     - uses: actions/checkout@v1
     - name: Generate projects
@@ -33,7 +33,7 @@ jobs:
 
 
   build_Example:
-    runs-on: macOS-12
+    runs-on: macOS-13
     steps:
     - uses: actions/checkout@v1
     - name: Generate projects
@@ -55,7 +55,7 @@ jobs:
         verbose: true
 
   build_tvOS:
-    runs-on: macOS-12
+    runs-on: macOS-13
     steps:
     - uses: actions/checkout@v1
     - name: Generate projects

--- a/Example/ReactiveDataDisplayManager/Extensions/UIBarButtonItem.swift
+++ b/Example/ReactiveDataDisplayManager/Extensions/UIBarButtonItem.swift
@@ -9,9 +9,9 @@ import UIKit
 
 public extension UIBarButtonItem {
 
-    static var empty: UIBarButtonItem = {
+    static var empty: UIBarButtonItem {
         let button = UIBarButtonItem(title: "Back", style: .plain, target: nil, action: nil)
         return button
-    }()
+    }
 
 }

--- a/Example/ReactiveDataDisplayManager/Extensions/UIButton.swift
+++ b/Example/ReactiveDataDisplayManager/Extensions/UIButton.swift
@@ -9,9 +9,9 @@ import UIKit
 
 public extension UIButton {
 
-    static var base: UIButton = {
+    static var base: UIButton {
         let button = UIButton(type: .roundedRect)
         return button
-    }()
+    }
 
 }

--- a/Example/ReactiveDataDisplayManager/Extensions/UILabel.swift
+++ b/Example/ReactiveDataDisplayManager/Extensions/UILabel.swift
@@ -9,12 +9,12 @@ import UIKit
 
 public extension UILabel {
 
-    static var base: UILabel = {
+    static var base: UILabel {
         let label = UILabel()
         label.textColor = .systemGray
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         return label
-    }()
+    }
 
 }

--- a/Example/ReactiveDataDisplayManager/Utils/UIViewController+Delay.swift
+++ b/Example/ReactiveDataDisplayManager/Utils/UIViewController+Delay.swift
@@ -11,7 +11,15 @@ import UIKit
 extension UIResponder {
 
     func delay(_ deadline: DispatchTime, completion: @escaping () -> Void) {
-        DispatchQueue.global(qos: .utility).asyncAfter(deadline: deadline) {
+        let normalizedDeadline: DispatchTime
+
+        if CommandLine.arguments.contains("-decreaseDelay") {
+            // to improve UI tests performance we are using one delay for any values
+            normalizedDeadline = .now() + .nanoseconds(100)
+        } else {
+            normalizedDeadline = deadline
+        }
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: normalizedDeadline) {
             DispatchQueue.main.async {
                 completion()
             }

--- a/Example/ReactiveDataDisplayManagerExampleUITests/BaseClasses/BaseUITestCase.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/BaseClasses/BaseUITestCase.swift
@@ -23,6 +23,7 @@ open class BaseUITestCase: XCTestCase {
         continueAfterFailure = false
         app = XCUIApplication()
         app.launchArguments.append("-disableAnimations")
+        app.launchArguments.append("-decreaseDelays")
         app.launchArguments.append("-rddm.XCUITestsCompatible")
         app.launchArguments.append(contentsOf: additionalCommands)
         app.launch()

--- a/Example/ReactiveDataDisplayManagerExampleUITests/BaseClasses/XCUIElement+Extensions.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/BaseClasses/XCUIElement+Extensions.swift
@@ -22,4 +22,13 @@ extension XCUIElement {
         return result == .completed
     }
 
+    func waitForLabelEqualTo(_ expectedLabel: String, timeout: TimeInterval) -> Bool {
+        let predicate = NSPredicate(format: "label == %@", expectedLabel)
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: self)
+
+        let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+
+        return result == .completed
+    }
+
 }

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/DragAndDroppablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/DragAndDroppablePluginExampleUITest.swift
@@ -27,11 +27,11 @@ final class DragAndDroppablePluginExampleUITest: BaseUITestCase {
         let destinationCell = getCell(for: .collection, collectionId: collectionId, cellId: destinationDraggable)
         sourceCell.press(forDuration: duration, thenDragTo: destinationCell)
 
-        wait(for: [], timeout: Constants.waitTime)
-
         let firstCell = getFirstCell(for: .collection, id: collectionId)
 
-        XCTAssertTrue(firstCell.label == destinationDraggable)
+        XCTAssertTrue(firstCell.waitForLabelEqualTo(destinationDraggable,
+                                                    timeout: Constants.waitTime)
+        )
     }
 
     func testTable_whenFirstCellDragingToDestination_thenDestinationCellBecomesFirst() throws {
@@ -47,11 +47,11 @@ final class DragAndDroppablePluginExampleUITest: BaseUITestCase {
         let destinationCell = getCell(for: .table, collectionId: tableId, cellId: destinationDraggable)
         sourceCell.press(forDuration: duration, thenDragTo: destinationCell)
 
-        wait(for: [], timeout: Constants.waitTime)
-
         let firstCell = getFirstCell(for: .table, id: tableId)
 
-        XCTAssertTrue(firstCell.label == destinationDraggable)
+        XCTAssertTrue(firstCell.waitForLabelEqualTo("Cell: 2",
+                                                    timeout: Constants.waitTime)
+        )
     }
 
 }

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/DragAndDroppablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/DragAndDroppablePluginExampleUITest.swift
@@ -11,7 +11,7 @@ final class DragAndDroppablePluginExampleUITest: BaseUITestCase {
 
     private enum Constants {
         static let dragDuration: TimeInterval = 1
-        static let waitTime: TimeInterval = 1.5 * dragDuration
+        static let waitTime: TimeInterval = 2.5 * dragDuration
     }
 
     func testСollection_whenFirstCellDragingToDestination_thenDestinationCellBecomesFirst() throws {
@@ -25,7 +25,7 @@ final class DragAndDroppablePluginExampleUITest: BaseUITestCase {
 
         let sourceCell = getCell(for: .collection, collectionId: collectionId, cellId: sourceDraggable)
         let destinationCell = getCell(for: .collection, collectionId: collectionId, cellId: destinationDraggable)
-        sourceCell.press(forDuration: duration, thenDragTo: destinationCell)
+        sourceCell.press(forDuration: duration, thenDragTo: destinationCell, withVelocity: .fast, thenHoldForDuration: .zero)
 
         let firstCell = getFirstCell(for: .collection, id: collectionId)
 
@@ -45,11 +45,11 @@ final class DragAndDroppablePluginExampleUITest: BaseUITestCase {
 
         let sourceCell = getCell(for: .table, collectionId: tableId, cellId: sourceDraggable)
         let destinationCell = getCell(for: .table, collectionId: tableId, cellId: destinationDraggable)
-        sourceCell.press(forDuration: duration, thenDragTo: destinationCell)
+        sourceCell.press(forDuration: duration, thenDragTo: destinationCell, withVelocity: .fast, thenHoldForDuration: .zero)
 
         let firstCell = getFirstCell(for: .table, id: tableId)
 
-        XCTAssertTrue(firstCell.waitForLabelEqualTo("Cell: 2",
+        XCTAssertTrue(firstCell.waitForLabelEqualTo(destinationDraggable,
                                                     timeout: Constants.waitTime)
         )
     }

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/DragAndDroppablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/DragAndDroppablePluginExampleUITest.swift
@@ -11,7 +11,7 @@ final class DragAndDroppablePluginExampleUITest: BaseUITestCase {
 
     private enum Constants {
         static let dragDuration: TimeInterval = 1
-        static let waitTime: UInt32 = UInt32(dragDuration)
+        static let waitTime: TimeInterval = 1.5 * dragDuration
     }
 
     func testСollection_whenFirstCellDragingToDestination_thenDestinationCellBecomesFirst() throws {
@@ -27,7 +27,8 @@ final class DragAndDroppablePluginExampleUITest: BaseUITestCase {
         let destinationCell = getCell(for: .collection, collectionId: collectionId, cellId: destinationDraggable)
         sourceCell.press(forDuration: duration, thenDragTo: destinationCell)
 
-        sleep(Constants.waitTime)
+        wait(for: [], timeout: Constants.waitTime)
+
         let firstCell = getFirstCell(for: .collection, id: collectionId)
 
         XCTAssertTrue(firstCell.label == destinationDraggable)
@@ -46,7 +47,8 @@ final class DragAndDroppablePluginExampleUITest: BaseUITestCase {
         let destinationCell = getCell(for: .table, collectionId: tableId, cellId: destinationDraggable)
         sourceCell.press(forDuration: duration, thenDragTo: destinationCell)
 
-        sleep(Constants.waitTime)
+        wait(for: [], timeout: Constants.waitTime)
+
         let firstCell = getFirstCell(for: .table, id: tableId)
 
         XCTAssertTrue(firstCell.label == destinationDraggable)

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/DragAndDroppablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/DragAndDroppablePluginExampleUITest.swift
@@ -11,7 +11,7 @@ final class DragAndDroppablePluginExampleUITest: BaseUITestCase {
 
     private enum Constants {
         static let dragDuration: TimeInterval = 1
-        static let waitTime: TimeInterval = 2.5 * dragDuration
+        static let waitTime: TimeInterval = 5 + dragDuration
     }
 
     func testСollection_whenFirstCellDragingToDestination_thenDestinationCellBecomesFirst() throws {

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/DragAndDroppablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/DragAndDroppablePluginExampleUITest.swift
@@ -11,7 +11,7 @@ final class DragAndDroppablePluginExampleUITest: BaseUITestCase {
 
     private enum Constants {
         static let dragDuration: TimeInterval = 1
-        static let waitTime: TimeInterval = 5 + dragDuration
+        static let waitTime: TimeInterval = 1.5 + dragDuration * 2
     }
 
     func testСollection_whenFirstCellDragingToDestination_thenDestinationCellBecomesFirst() throws {
@@ -25,7 +25,7 @@ final class DragAndDroppablePluginExampleUITest: BaseUITestCase {
 
         let sourceCell = getCell(for: .collection, collectionId: collectionId, cellId: sourceDraggable)
         let destinationCell = getCell(for: .collection, collectionId: collectionId, cellId: destinationDraggable)
-        sourceCell.press(forDuration: duration, thenDragTo: destinationCell, withVelocity: .fast, thenHoldForDuration: .zero)
+        sourceCell.press(forDuration: duration, thenDragTo: destinationCell, withVelocity: .slow, thenHoldForDuration: duration)
 
         let firstCell = getFirstCell(for: .collection, id: collectionId)
 
@@ -45,7 +45,7 @@ final class DragAndDroppablePluginExampleUITest: BaseUITestCase {
 
         let sourceCell = getCell(for: .table, collectionId: tableId, cellId: sourceDraggable)
         let destinationCell = getCell(for: .table, collectionId: tableId, cellId: destinationDraggable)
-        sourceCell.press(forDuration: duration, thenDragTo: destinationCell, withVelocity: .fast, thenHoldForDuration: .zero)
+        sourceCell.press(forDuration: duration, thenDragTo: destinationCell, withVelocity: .slow, thenHoldForDuration: duration)
 
         let firstCell = getFirstCell(for: .table, id: tableId)
 

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/FoldablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/FoldablePluginExampleUITest.swift
@@ -28,7 +28,7 @@ final class FoldablePluginExampleUITest: BaseUITestCase {
 
     func testCollectionMultipleTap_whenCellTapped_thenCellSelected_thenCellDeselected() throws {
         setTab("Collection")
-        tapTableElement("Foldable collection")
+        tapTableElement("foldable collection")
 
         let collection = app.collectionViews.firstMatch
 

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/HighlightablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/HighlightablePluginExampleUITest.swift
@@ -59,7 +59,7 @@ final class HighlightablePluginExampleUITest: BaseUITestCase {
         var wasPresed = false
 
         setTab("Collection")
-        tapTableElement("Base collection view")
+        tapTableElement("base collection view")
 
         let cell = getFirstCell(for: .collection, id: "Collection_with_selectable_cells")
 
@@ -79,7 +79,7 @@ final class HighlightablePluginExampleUITest: BaseUITestCase {
         let normalStyle = "Normal"
 
         setTab("Collection")
-        tapTableElement("Base collection view")
+        tapTableElement("base collection view")
         tapButton("Single mode")
 
         let cell = getFirstCell(for: .collection, id: "Collection_with_selectable_cells")

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/HighlightablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/HighlightablePluginExampleUITest.swift
@@ -25,9 +25,9 @@ final class HighlightablePluginExampleUITest: BaseUITestCase {
             wasPresed = cell.stringValue == highlightedStyle
             expectation.fulfill()
         }
-        cell.press(forDuration: 2)
+        cell.press(forDuration: 2 * timeout)
 
-        wait(for: [expectation], timeout: timeout)
+        wait(for: [expectation], timeout: 2 * timeout)
         XCTAssertTrue(wasPresed)
         XCTAssertEqual(cell.stringValue, normalStyle)
     }
@@ -67,9 +67,9 @@ final class HighlightablePluginExampleUITest: BaseUITestCase {
             wasPresed = cell.stringValue == highlightedStyle
             expectation.fulfill()
         }
-        cell.press(forDuration: 2)
+        cell.press(forDuration: 2 * timeout)
 
-        wait(for: [expectation], timeout: timeout)
+        wait(for: [expectation], timeout: 2 * timeout)
         XCTAssertTrue(wasPresed)
         XCTAssertEqual(cell.stringValue, normalStyle)
     }

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/MovablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/MovablePluginExampleUITest.swift
@@ -10,8 +10,8 @@ import XCTest
 final class MovablePluginExampleUITest: BaseUITestCase {
 
     private enum Constants {
-        static let dragDuration = 0.5
-        static let waitTime: UInt32 = 1
+        static let dragDuration: TimeInterval = 1
+        static let waitTime: TimeInterval = 1.5 * dragDuration
     }
 
     func testСollection_whenFirstCellDragingToDestination_thenDestinationCellBecomesFirst() throws {
@@ -27,7 +27,8 @@ final class MovablePluginExampleUITest: BaseUITestCase {
         let destinationCell = getCell(for: .collection, collectionId: collectionId, cellId: destinationDraggable)
         sourceCell.press(forDuration: duration, thenDragTo: destinationCell, withVelocity: .slow, thenHoldForDuration: duration)
 
-        sleep(Constants.waitTime)
+        wait(for: [], timeout: Constants.waitTime, enforceOrder: false)
+
         let firstCell = getFirstCell(for: .collection, id: collectionId)
 
         XCTAssertTrue(firstCell.label == destinationDraggable)
@@ -53,7 +54,8 @@ final class MovablePluginExampleUITest: BaseUITestCase {
                    withVelocity: .slow,
                    thenHoldForDuration: duration)
 
-        sleep(Constants.waitTime)
+        wait(for: [], timeout: Constants.waitTime, enforceOrder: false)
+
         let firstCell = getFirstCell(for: .table, id: tableId)
 
         XCTAssertTrue(firstCell.label == "Cell: 2")

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/MovablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/MovablePluginExampleUITest.swift
@@ -11,7 +11,7 @@ final class MovablePluginExampleUITest: BaseUITestCase {
 
     private enum Constants {
         static let dragDuration: TimeInterval = 1
-        static let waitTime: TimeInterval = 1.5 * dragDuration
+        static let waitTime: TimeInterval = 1.5 + dragDuration * 2
     }
 
     func testСollection_whenFirstCellDragingToDestination_thenDestinationCellBecomesFirst() throws {

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/MovablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/MovablePluginExampleUITest.swift
@@ -27,11 +27,11 @@ final class MovablePluginExampleUITest: BaseUITestCase {
         let destinationCell = getCell(for: .collection, collectionId: collectionId, cellId: destinationDraggable)
         sourceCell.press(forDuration: duration, thenDragTo: destinationCell, withVelocity: .slow, thenHoldForDuration: duration)
 
-        wait(for: [], timeout: Constants.waitTime, enforceOrder: false)
-
         let firstCell = getFirstCell(for: .collection, id: collectionId)
 
-        XCTAssertTrue(firstCell.label == destinationDraggable)
+        XCTAssertTrue(firstCell.waitForLabelEqualTo(destinationDraggable,
+                                                    timeout: Constants.waitTime)
+        )
     }
 
     func testTable_whenFirstCellDragingToDestination_thenDestinationCellBecomesFirst() throws {
@@ -54,11 +54,11 @@ final class MovablePluginExampleUITest: BaseUITestCase {
                    withVelocity: .slow,
                    thenHoldForDuration: duration)
 
-        wait(for: [], timeout: Constants.waitTime, enforceOrder: false)
-
         let firstCell = getFirstCell(for: .table, id: tableId)
 
-        XCTAssertTrue(firstCell.label == "Cell: 2")
+        XCTAssertTrue(firstCell.waitForLabelEqualTo("Cell: 2",
+                                                    timeout: Constants.waitTime)
+        )
     }
 
 }

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/RefreshablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/RefreshablePluginExampleUITest.swift
@@ -37,7 +37,7 @@ final class RefreshablePluginExampleUITest: BaseUITestCase {
 
     func testCollection_whenScrollDown_thenShowRefreshControl() throws {
         setTab("Collection")
-        tapTableElement("Collection list with refreshing")
+        tapTableElement("collection list with refreshing")
 
         let cell = getFirstCell(for: .collection, id: "Refrashable_collection_list")
         let refreshControl = app.otherElements["RefreshableCollectionViewController_RefreshControl"]

--- a/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/SelectablePluginExampleUITest.swift
+++ b/Example/ReactiveDataDisplayManagerExampleUITests/Plugins/SelectablePluginExampleUITest.swift
@@ -37,7 +37,7 @@ final class SelectablePluginExampleUITest: BaseUITestCase {
 
     func testCollectionMultipleTap_whenCellTapped_thenCellSelected_thenCellDeselected() throws {
         setTab("Collection")
-        tapTableElement("Base collection view")
+        tapTableElement("base collection view")
         tapButton("Single mode")
 
         let cell = getFirstCell(for: .collection, id: "Collection_with_selectable_cells")
@@ -51,7 +51,7 @@ final class SelectablePluginExampleUITest: BaseUITestCase {
 
     func testCollectionSingleTap_whenCellTapped_thenCellNotSelected() throws {
         setTab("Collection")
-        tapTableElement("Base collection view")
+        tapTableElement("base collection view")
 
         let cell = getFirstCell(for: .collection, id: "Collection_with_selectable_cells")
 

--- a/Example/project.yml
+++ b/Example/project.yml
@@ -20,6 +20,11 @@ targets:
     ReactiveDataDisplayManagerExample_iOS:
       platform: iOS
       deploymentTarget: 11.0
+      scheme:
+        configVariants: all
+        testTargets:
+            - ReactiveDataDisplayManagerExampleUITests
+        gatherCoverageData: true
       sources:
         - path: ReactiveDataDisplayManager
       dependencies:
@@ -32,7 +37,6 @@ targets:
       templateAttributes:
         bundle_id: ru.surfstudio.rddm.example
         bundle_name: ReactiveDataDisplayManagerExample
-        ui_test: ReactiveDataDisplayManagerExampleUITests
 
     ReactiveDataDisplayManagerExample_tvOS:
       platform: tvOS
@@ -49,7 +53,6 @@ targets:
       templateAttributes:
         bundle_id: ru.surfstudio.rddm.tv_example
         bundle_name: ReactiveDataDisplayManagerExampleTv
-        ui_test: ReactiveDataDisplayManagerExampleUITests
 
     ReactiveDataDisplayManagerExampleUITests:
         templates:

--- a/Example/targets/template.yml
+++ b/Example/targets/template.yml
@@ -6,8 +6,6 @@ targetTemplates:
       type: application
       scheme:
         configVariants: all
-        testTargets:
-            - ${ui_test}
         gatherCoverageData: true
       dependencies:
         - sdk: UIKit.framework

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,20 @@ build_lib_iOS:
 
 ## Run tests of lib for **iOS** platform
 test_lib_iOS:
-	xcodebuild test-without-building -scheme ReactiveDataDisplayManager_iOS -configuration "Debug" -sdk iphonesimulator -enableCodeCoverage YES -destination ${destination} | bundle exec xcpretty -c
+	xcodebuild test-without-building -scheme ReactiveDataDisplayManager_iOS -configuration "Debug" -sdk iphonesimulator -enableCodeCoverage YES -destination ${destination} | bundle exec xcpretty -c | tee build/reports/xcodebuild.log
+
+## Count failures in xcodebuild.log and `exit 0` if no failures or `exit 1` otherwise
+check_test_log:
+	echo "Test results: build/reports/xcodebuild.log"
+	$(eval failures_count := $(shell cat build/reports/xcodebuild.log | grep -Eo "[0-9]+ failures" | grep -Eo "[0-9]+"))
+	echo "Failures count: $(failures_count)"
+	@if [ $(failures_count) == "0" ]; then\
+		echo "Tests passed";\
+		exit 0;\
+	else\
+		echo "Tests failed";\
+		exit 1;\
+	fi
 
 ## Preparing report contains test-coverage results
 prepare_report:
@@ -50,7 +63,7 @@ build_example_iOS:
 
 ## Run tests of Example for **iOS** platform
 test_example_iOS:
-	xcodebuild test-without-building -workspace ReactiveDataDisplayManager.xcworkspace -scheme ReactiveDataDisplayManagerExample_iOS -configuration "Debug" -sdk iphonesimulator -enableCodeCoverage YES -destination ${destination} | bundle exec xcpretty -c
+	xcodebuild test-without-building -workspace ReactiveDataDisplayManager.xcworkspace -scheme ReactiveDataDisplayManagerExample_iOS -configuration "Debug" -sdk iphonesimulator -enableCodeCoverage YES -destination ${destination} | bundle exec xcpretty -c | tee build/reports/xcodebuild.log
 
 ## Preparing report contains test-coverage results
 prepare_example_report:

--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,12 @@ build_lib_iOS:
 
 ## Run tests of lib for **iOS** platform
 test_lib_iOS:
-	xcodebuild test-without-building -scheme ReactiveDataDisplayManager_iOS -configuration "Debug" -sdk iphonesimulator -enableCodeCoverage YES -destination ${destination} | bundle exec xcpretty -c | tee build/reports/xcodebuild.log
+	xcodebuild test-without-building -scheme ReactiveDataDisplayManager_iOS -configuration "Debug" -sdk iphonesimulator -enableCodeCoverage YES -destination ${destination} | bundle exec xcpretty -c | tee xcodebuild.log
 
 ## Count failures in xcodebuild.log and `exit 0` if no failures or `exit 1` otherwise
 check_test_log:
-	echo "Test results: build/reports/xcodebuild.log"
-	$(eval failures_count := $(shell cat build/reports/xcodebuild.log | grep -Eo "[0-9]+ failures" | grep -Eo "[0-9]+"))
+	echo "Test results: xcodebuild.log"
+	$(eval failures_count := $(shell cat xcodebuild.log | grep -Eo "[0-9]+ failures" | grep -Eo "[0-9]+"))
 	echo "Failures count: $(failures_count)"
 	@if [ $(failures_count) == "0" ]; then\
 		echo "Tests passed";\
@@ -63,7 +63,7 @@ build_example_iOS:
 
 ## Run tests of Example for **iOS** platform
 test_example_iOS:
-	xcodebuild test-without-building -workspace ReactiveDataDisplayManager.xcworkspace -scheme ReactiveDataDisplayManagerExample_iOS -configuration "Debug" -sdk iphonesimulator -enableCodeCoverage YES -destination ${destination} | bundle exec xcpretty -c | tee build/reports/xcodebuild.log
+	xcodebuild test-without-building -workspace ReactiveDataDisplayManager.xcworkspace -scheme ReactiveDataDisplayManagerExample_iOS -configuration "Debug" -sdk iphonesimulator -enableCodeCoverage YES -destination ${destination} | bundle exec xcpretty -c | tee xcodebuild.log
 
 ## Preparing report contains test-coverage results
 prepare_example_report:

--- a/ReactiveDataDisplayManagerTests/XCTestCase+FatalError.swift
+++ b/ReactiveDataDisplayManagerTests/XCTestCase+FatalError.swift
@@ -19,22 +19,15 @@ extension XCTestCase {
         FatalErrorUtil.replaceFatalError { message, _, _ in
             assertionMessage = message
             expectation.fulfill()
-            self.unreachable()
         }
 
-        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + .milliseconds(200), execute: testcase)
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200), execute: testcase)
 
-        waitForExpectations(timeout: 3) { _ in
+        waitForExpectations(timeout: 1) { _ in
             XCTAssertEqual(assertionMessage, expectedMessage)
 
             FatalErrorUtil.restoreFatalError()
         }
-    }
-
-    private func unreachable() -> Never {
-        repeat {
-            RunLoop.current.run()
-        } while (true)
     }
 
 }

--- a/ReactiveDataDisplayManagerTests/XCTestCase+FatalError.swift
+++ b/ReactiveDataDisplayManagerTests/XCTestCase+FatalError.swift
@@ -22,7 +22,7 @@ extension XCTestCase {
             self.unreachable()
         }
 
-        DispatchQueue.global(qos: .userInitiated).async(execute: testcase)
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + .milliseconds(200), execute: testcase)
 
         waitForExpectations(timeout: 3) { _ in
             XCTAssertEqual(assertionMessage, expectedMessage)

--- a/Source/Collection/Deprecated/BaseCollectionDataDisplayManager.swift
+++ b/Source/Collection/Deprecated/BaseCollectionDataDisplayManager.swift
@@ -75,7 +75,7 @@ extension BaseCollectionDataDisplayManager: DataDisplayManager {
     public func addCellGenerators(_ generators: [CollectionCellGenerator], after: CollectionCellGenerator) {
         generators.forEach { $0.registerCell(in: view) }
         guard let (sectionIndex, generatorIndex) = findGenerator(after) else {
-            fatalError("Error adding cell generator. You tried to add generators after unexisted generator")
+            return FatalErrorUtil.fatalError("Error adding cell generator. You tried to add generators after unexisted generator")
         }
         self.cellGenerators[sectionIndex].insert(contentsOf: generators, at: generatorIndex + 1)
     }

--- a/Source/Collection/Manager/BaseCollectionManager.swift
+++ b/Source/Collection/Manager/BaseCollectionManager.swift
@@ -68,7 +68,7 @@ open class BaseCollectionManager: CollectionGeneratorsProvider, DataDisplayManag
         generators.forEach { $0.registerCell(in: view) }
 
         guard let (sectionIndex, generatorIndex) = findGenerator(after) else {
-            fatalError("Error adding cell generator. You tried to add generators after unexisted generator")
+            return FatalErrorUtil.fatalError("Error adding cell generator. You tried to add generators after unexisted generator")
         }
 
         self.generators[sectionIndex].insert(contentsOf: generators, at: generatorIndex + 1)

--- a/Source/Table/Deprecated/BaseTableDataDisplayManager.swift
+++ b/Source/Table/Deprecated/BaseTableDataDisplayManager.swift
@@ -71,10 +71,10 @@ extension BaseTableDataDisplayManager: DataDisplayManager {
 
     public func insert(headGenerator: TableHeaderGenerator, after: TableHeaderGenerator) {
         if self.sectionHeaderGenerators.contains(where: { $0 === headGenerator }) {
-            fatalError("Error adding header generator. Header generator was added earlier")
+            return FatalErrorUtil.fatalError("Error adding header generator. Header generator was added earlier")
         }
         guard let anchorIndex = self.sectionHeaderGenerators.firstIndex(where: { $0 === after }) else {
-            fatalError("Error adding header generator. You tried to add generators after unexisted generator")
+            return FatalErrorUtil.fatalError("Error adding header generator. You tried to add generators after unexisted generator")
         }
         let newIndex = anchorIndex + 1
         self.insert(headGenerator: headGenerator, by: newIndex)
@@ -82,10 +82,10 @@ extension BaseTableDataDisplayManager: DataDisplayManager {
 
     public func insert(headGenerator: TableHeaderGenerator, before: TableHeaderGenerator) {
         if self.sectionHeaderGenerators.contains(where: { $0 === headGenerator }) {
-            fatalError("Error adding header generator. Header generator was added earlier")
+            return FatalErrorUtil.fatalError("Error adding header generator. Header generator was added earlier")
         }
         guard let anchorIndex = self.sectionHeaderGenerators.firstIndex(where: { $0 === before }) else {
-            fatalError("Error adding header generator. You tried to add generators after unexisted generator")
+            return FatalErrorUtil.fatalError("Error adding header generator. You tried to add generators after unexisted generator")
         }
         let newIndex = max(anchorIndex - 1, 0)
         self.insert(headGenerator: headGenerator, by: newIndex)
@@ -117,7 +117,7 @@ extension BaseTableDataDisplayManager: DataDisplayManager {
     public func addCellGenerators(_ generators: [TableCellGenerator], after: TableCellGenerator) {
         generators.forEach { $0.registerCell(in: view) }
         guard let (sectionIndex, generatorIndex) = findGenerator(after) else {
-            fatalError("Error adding cell generator. You tried to add generators after unexisted generator")
+            return FatalErrorUtil.fatalError("Error adding cell generator. You tried to add generators after unexisted generator")
         }
         self.cellGenerators[sectionIndex].insert(contentsOf: generators, at: generatorIndex + 1)
     }

--- a/Source/Table/Manager/BaseTableManager.swift
+++ b/Source/Table/Manager/BaseTableManager.swift
@@ -58,7 +58,7 @@ open class BaseTableManager: TableGeneratorsProvider, DataDisplayManager {
     open func addCellGenerators(_ generators: [TableCellGenerator], after: TableCellGenerator) {
         generators.forEach { $0.registerCell(in: view) }
         guard let (sectionIndex, generatorIndex) = findGenerator(after) else {
-            fatalError("Error adding TableCellGenerator generator. You tried to add generators after unexisted generator")
+            return FatalErrorUtil.fatalError("Error adding TableCellGenerator generator. You tried to add generators after unexisted generator")
         }
         self.generators[sectionIndex].insert(contentsOf: generators, at: generatorIndex + 1)
     }

--- a/Source/Table/Manager/GravityTableManager.swift
+++ b/Source/Table/Manager/GravityTableManager.swift
@@ -16,7 +16,7 @@ extension EmptyTableHeaderGenerator: GravityItem {
     // swiftlint:disable unused_setter_value
     public var heaviness: Int {
         get { return self.getHeaviness() }
-        set { fatalError() }
+        set { return FatalErrorUtil.fatalError() }
     }
     // swiftlint:enable unused_setter_value
 }

--- a/Source/Table/Manager/ManualTableManager.swift
+++ b/Source/Table/Manager/ManualTableManager.swift
@@ -31,10 +31,10 @@ public class ManualTableManager: BaseTableManager {
     ///   - after: TableHeaderGenerator, after which new TableHeaderGenerator will be added.
     open func insert(headGenerator: TableHeaderGenerator, after: TableHeaderGenerator) {
         if self.sections.contains(where: { $0 === headGenerator }) {
-            fatalError("Error adding TableHeaderGenerator generator. TableHeaderGenerator generator was added earlier")
+            return FatalErrorUtil.fatalError("Error adding TableHeaderGenerator generator. TableHeaderGenerator generator was added earlier")
         }
         guard let anchorIndex = self.sections.firstIndex(where: { $0 === after }) else {
-            fatalError("Error adding TableHeaderGenerator generator. You tried to add generators after unexisted generator")
+            return FatalErrorUtil.fatalError("Error adding TableHeaderGenerator generator. You tried to add generators after unexisted generator")
         }
         let newIndex = anchorIndex + 1
         self.insert(headGenerator: headGenerator, by: newIndex)
@@ -47,10 +47,10 @@ public class ManualTableManager: BaseTableManager {
     ///   - after: TableHeaderGenerator, before which new TableHeaderGenerator will be added.
     open func insert(headGenerator: TableHeaderGenerator, before: TableHeaderGenerator) {
         if self.sections.contains(where: { $0 === headGenerator }) {
-            fatalError("Error adding TableHeaderGenerator generator. TableHeaderGenerator generator was added earlier")
+            return FatalErrorUtil.fatalError("Error adding TableHeaderGenerator generator. TableHeaderGenerator generator was added earlier")
         }
         guard let anchorIndex = self.sections.firstIndex(where: { $0 === before }) else {
-            fatalError("Error adding TableHeaderGenerator generator. You tried to add generators after unexisted generator")
+            return FatalErrorUtil.fatalError("Error adding TableHeaderGenerator generator. You tried to add generators after unexisted generator")
         }
         let newIndex = max(anchorIndex - 1, 0)
         self.insert(headGenerator: headGenerator, by: newIndex)

--- a/Source/Utils/FatalErrorUtil.swift
+++ b/Source/Utils/FatalErrorUtil.swift
@@ -8,17 +8,17 @@
 
 import UIKit
 
-func fatalError(_ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) -> Never {
-    FatalErrorUtil.fatalErrorClosure(message(), file, line)
-}
+enum FatalErrorUtil {
 
-struct FatalErrorUtil {
+    static var fatalErrorClosure: (String, StaticString, UInt) -> Void = defaultFatalErrorClosure
 
-    static var fatalErrorClosure: (String, StaticString, UInt) -> Never = defaultFatalErrorClosure
+    private static let defaultFatalErrorClosure: (String, StaticString, UInt) -> Void = { Swift.fatalError($0, file: $1, line: $2) }
 
-    private static let defaultFatalErrorClosure = { Swift.fatalError($0, file: $1, line: $2) }
+    static func fatalError(_ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+        fatalErrorClosure(message(), file, line)
+    }
 
-    static func replaceFatalError(closure: @escaping (String, StaticString, UInt) -> Never) {
+    static func replaceFatalError(closure: @escaping (String, StaticString, UInt) -> Void) {
         fatalErrorClosure = closure
     }
 


### PR DESCRIPTION
## Что сделано?

- Поправлены заголовки экранов в UI тестах
- Оптимизированы тесты movable и dragable
- ...

## Зачем это сделано?

Чтобы повысить качество и стабильность прогона тестов на CI

## На что обратить внимание?

- Локально прогонялось на Xcode 15. 3 раза - все зеленое
- Проблема в том, что некоторые тесты время от времени падали на CI и это не отражалось в build check. Проблема известная, но хочется решить ее не так как на stackOv - https://stackoverflow.com/questions/58694624/xcode-test-failing-does-not-failed-github-action-pipeline 
- ...

## Как протестировать?

- Запустить тесты несколько раз
(для ускорения можно в схеме включить параллельное тестирование )
![Снимок экрана 2023-06-21 в 20 58 22](https://github.com/surfstudio/ReactiveDataDisplayManager/assets/28707156/76f33420-5e90-41d8-a907-b4a32f18dd16)

- Написать в случае нахождения плавающих падений (которые фиксятся перезапуском теста) 
