### PR TITLE
[SPT-1364] [Коллекция] Плагин TwoDirectionalPaginatable

### DIFF
--- a/Example/ReactiveDataDisplayManager/Collection.storyboard
+++ b/Example/ReactiveDataDisplayManager/Collection.storyboard
@@ -6,7 +6,6 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
-        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -677,22 +676,14 @@
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="TXb-Mz-Sn1">
                                 <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="cvv-hB-uev">
-                                    <size key="itemSize" width="128" height="128"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="cvv-hB-uev">
+                                    <size key="itemSize" width="200" height="44"/>
+                                    <size key="estimatedItemSize" width="200" height="44"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
-                                <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="fK8-9Q-5Ed">
-                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="2Bf-HK-vdg">
-                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </collectionViewCellContentView>
-                                    </collectionViewCell>
-                                </cells>
+                                <cells/>
                             </collectionView>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" id="eQK-He-szX">
                                 <rect key="frame" x="0.0" y="87" width="414" height="721"/>

--- a/Example/ReactiveDataDisplayManager/Collection.storyboard
+++ b/Example/ReactiveDataDisplayManager/Collection.storyboard
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -18,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="A8g-Fk-bs3">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
                         </subviews>
@@ -53,6 +54,7 @@
                         <segue destination="FGo-hQ-mlr" kind="show" identifier="alignedCollection" id="25y-gf-PJh"/>
                         <segue destination="sgs-NW-3gA" kind="show" identifier="dynamicHeightViewController" id="e8g-5H-pyR"/>
                         <segue destination="EB6-CQ-xkp" kind="show" identifier="refreshingCollection" id="RIR-tI-dAc"/>
+                        <segue destination="dcC-YA-wFj" kind="show" identifier="twoDirectionPaginatableCollection" id="EKN-aB-kFO"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4hK-7m-aH1" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -68,7 +70,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="IvU-EW-LcO">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="mef-ir-Kg4">
                                     <size key="itemSize" width="128" height="128"/>
@@ -106,7 +108,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="6AU-8s-aNT">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="va3-A8-F2n">
                                     <size key="itemSize" width="128" height="128"/>
@@ -144,7 +146,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="AUa-aU-6Jt">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="ThD-7j-05c">
                                     <size key="itemSize" width="128" height="128"/>
@@ -182,7 +184,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="e1H-e5-fjc">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="bia-fd-o5s">
                                     <size key="itemSize" width="100" height="50"/>
@@ -220,7 +222,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="GhA-Hz-PgI">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Qme-oq-gRi">
                                     <size key="itemSize" width="128" height="128"/>
@@ -258,7 +260,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="3V1-Nv-1no">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewLayout key="collectionViewLayout" id="QbP-og-z4S"/>
                                 <cells/>
@@ -291,7 +293,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="3LO-Ai-sbs">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
                         </subviews>
@@ -322,7 +324,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="5gv-WR-Fgc">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="WY2-6o-ReP">
                                     <size key="itemSize" width="128" height="128"/>
@@ -360,7 +362,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="92L-DJ-Zxp">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="omp-nY-qqc">
                                     <size key="itemSize" width="128" height="128"/>
@@ -398,7 +400,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" directionalLockEnabled="YES" alwaysBounceVertical="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="K3N-Yx-DnP">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="tmh-tb-lqk">
                                     <size key="itemSize" width="128" height="128"/>
@@ -436,7 +438,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="qMb-HN-C4b">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="x9p-pT-V5n">
                                     <size key="itemSize" width="128" height="128"/>
@@ -474,7 +476,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="gRl-8w-vfc">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="xCh-EV-86V">
                                     <size key="itemSize" width="128" height="128"/>
@@ -512,7 +514,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Hu0-iy-wNb">
-                                <rect key="frame" x="0.0" y="88" width="414" height="140"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="140"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="140" id="qHo-BH-Imt"/>
@@ -552,7 +554,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="e1c-kv-Bxw">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="ZzD-oI-SXn">
                                     <size key="itemSize" width="128" height="128"/>
@@ -590,7 +592,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="0bE-3M-MgI">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="VcJ-m3-1af">
                                     <size key="itemSize" width="128" height="128"/>
@@ -628,7 +630,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="MvZ-bc-XsG">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="k5A-k1-PTS">
                                     <size key="itemSize" width="200" height="44"/>
@@ -640,7 +642,7 @@
                                 <cells/>
                             </collectionView>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="1mH-ae-3Sl">
-                                <rect key="frame" x="197" y="440.5" width="20" height="20"/>
+                                <rect key="frame" x="197" y="442.5" width="20" height="20"/>
                             </activityIndicatorView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="1e5-a4-Ekt"/>
@@ -664,6 +666,58 @@
             </objects>
             <point key="canvasLocation" x="5843.4782608695659" y="1618.5267857142856"/>
         </scene>
+        <!--Two Direction Paginatable Collection View Controller-->
+        <scene sceneID="M0t-LM-OOh">
+            <objects>
+                <viewController id="dcC-YA-wFj" customClass="TwoDirectionPaginatableCollectionViewController" customModule="ReactiveDataDisplayManagerExample_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="DGd-zZ-ypW">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="TXb-Mz-Sn1">
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="cvv-hB-uev">
+                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="fK8-9Q-5Ed">
+                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="2Bf-HK-vdg">
+                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </collectionViewCellContentView>
+                                    </collectionViewCell>
+                                </cells>
+                            </collectionView>
+                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" id="eQK-He-szX">
+                                <rect key="frame" x="0.0" y="87" width="414" height="721"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            </activityIndicatorView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="v95-IH-wKb"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="v95-IH-wKb" firstAttribute="trailing" secondItem="TXb-Mz-Sn1" secondAttribute="trailing" id="0y1-O7-uQS"/>
+                            <constraint firstItem="TXb-Mz-Sn1" firstAttribute="leading" secondItem="v95-IH-wKb" secondAttribute="leading" id="Zb1-ac-wFk"/>
+                            <constraint firstItem="v95-IH-wKb" firstAttribute="bottom" secondItem="TXb-Mz-Sn1" secondAttribute="bottom" id="lhp-vH-dAR"/>
+                            <constraint firstItem="TXb-Mz-Sn1" firstAttribute="top" secondItem="v95-IH-wKb" secondAttribute="top" id="yv0-1B-ANp"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="cBN-Mv-Opx"/>
+                    <connections>
+                        <outlet property="activityIndicator" destination="eQK-He-szX" id="5H9-jx-I6a"/>
+                        <outlet property="collectionView" destination="TXb-Mz-Sn1" id="6M3-cy-cME"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="OFx-nr-qoa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="5843" y="2369"/>
+        </scene>
         <!--Collection Compositional View Controller-->
         <scene sceneID="UQ3-Rr-dvo">
             <objects>
@@ -673,7 +727,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="sru-Fy-rgB">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="DI9-aZ-sm7">
                                     <size key="itemSize" width="128" height="128"/>
@@ -711,7 +765,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="zly-mA-StE">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Yn3-gT-ACL">
                                     <size key="itemSize" width="128" height="128"/>
@@ -748,7 +802,7 @@
                     <toolbarItems/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="G0m-QT-JKU">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -769,7 +823,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Hye-pv-3Ii">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="721"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="376-WV-gUV">
                                     <size key="itemSize" width="128" height="128"/>

--- a/Example/ReactiveDataDisplayManager/Collection/MainCollectionViewController/MainCollectionViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Collection/MainCollectionViewController/MainCollectionViewController.swift
@@ -33,6 +33,7 @@ final class MainCollectionViewController: UIViewController {
         case carouselCollection
         case alignedCollection
         case dynamicHeightViewController
+        case twoDirectionPaginatableCollection
     }
 
     // MARK: - Constants
@@ -50,6 +51,7 @@ final class MainCollectionViewController: UIViewController {
             ("Collection with item index titles", .itemTitleCollection),
             ("Collection with diffableDataSource", .diffableCollection),
             ("Collection with pagination", .paginatableCollection),
+            ("Collection with two direction pagination", .twoDirectionPaginatableCollection),
             ("Collection with compositional layout", .compositionalCollection),
             ("Collection with DifferenceKit", .differenceCollection),
             ("List Appearances with swipeable items", .swipeableListAppearances),

--- a/Example/ReactiveDataDisplayManager/Collection/TwoDirectionPaginatableCollectionViewController/TwoDirectionPaginatableCollectionViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Collection/TwoDirectionPaginatableCollectionViewController/TwoDirectionPaginatableCollectionViewController.swift
@@ -155,7 +155,7 @@ private extension TwoDirectionPaginatableCollectionViewController {
         let newGenerators = (0...Constants.pageSize).map { _ in
             return makeGenerator()
         }
-        adapter.insert(after: emptyCell, new: newGenerators)
+        adapter.insert(after: emptyCell, new: newGenerators, with: nil)
 
         // pages count is infinite if it`s a single direction scroll
         return currentPage != 0
@@ -208,48 +208,19 @@ extension TwoDirectionPaginatableCollectionViewController: BackwardPaginatableOu
                 return
             }
             if self.canFillPages() {
+                let initialContentHeight = self.collectionView.contentSize.height
+
                 let canIterate = self.fillPrev()
                 input?.updateProgress(isLoading: false)
                 input?.updatePagination(canIterate: canIterate)
                 self.forwardPaginatableInput?.updatePagination(canIterate: canIterate)
-                
+
                 self.collectionView.scrollToItem(at: IndexPath(item: Constants.pageSize, section: 0), at: .top, animated: false)
 
-                //option 1
-//                let initialGeneratorsHeight = self.adapter.sections.first?.generators.reduce(0) {
-//                    if let cell = $1 as? CalculatableHeightCollectionCellGenerator<TitleCollectionViewCell> {
-//                        return ($0 + cell.getSize().height)
-//                    } else {
-//                        return $0
-//                    }
-//                }
-//option 2
-//                let initialContentHeight = self.collectionView.collectionViewLayout.collectionViewContentSize.height
-//
-//                let canIterate = self.fillPrev()
-//                input?.updateProgress(isLoading: false)
-//                input?.updatePagination(canIterate: canIterate)
-//                self.forwardPaginatableInput?.updatePagination(canIterate: canIterate)
-//option 1
-//                let newGeneratorsHeight = self.adapter.sections.first?.generators.reduce(0) {
-//                    if let cell = $1 as? CalculatableHeightCollectionCellGenerator<TitleCollectionViewCell> {
-//                        return ($0 + cell.getSize().height)
-//                    } else {
-//                        return $0
-//                    }
-//                }
-//
-//                if let initialGeneratorsHeight = initialGeneratorsHeight, let newGeneratorsHeight = newGeneratorsHeight {
-//                    let finalOffset = CGPoint(x: 0, y: newGeneratorsHeight - initialGeneratorsHeight)
-//                    self.collectionView.setContentOffset(finalOffset, animated: false)
-//                }
-//option 2
+                let newContentHeight = self.collectionView.contentSize.height
 
-//                self.view.layoutIfNeeded()
-//                let newContentHeight = self.collectionView.collectionViewLayout.collectionViewContentSize.height
-//
-//                let finalOffset = CGPoint(x: 0, y: initialContentHeight - newContentHeight)
-//                self.collectionView.setContentOffset(finalOffset, animated: false)
+                let finalOffset = CGPoint(x: 0, y: newContentHeight - initialContentHeight - Constants.paginatorHeight)
+                self.collectionView.setContentOffset(finalOffset, animated: false)
             } else {
                     input?.updateProgress(isLoading: false)
                     input?.updateError(SampleError.sample)

--- a/Example/ReactiveDataDisplayManager/Collection/TwoDirectionPaginatableCollectionViewController/TwoDirectionPaginatableCollectionViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Collection/TwoDirectionPaginatableCollectionViewController/TwoDirectionPaginatableCollectionViewController.swift
@@ -26,9 +26,14 @@ final class TwoDirectionPaginatableCollectionViewController: UIViewController {
 
     // MARK: - Private Properties
 
-    private lazy var forwardProgressView = PaginatorView(frame: .init(x: 0, y: 0, width: collectionView.frame.width, height: Constants.paginatorHeight))
-    private lazy var backwardProgressView = PaginatorView(frame: .init(x: 0, y: 0, width: collectionView.frame.width, height: Constants.paginatorHeight))
-    
+    private lazy var forwardProgressView = PaginatorView(frame: .init(x: 0,
+                                                                      y: 0,
+                                                                      width: collectionView.frame.width,
+                                                                      height: Constants.paginatorHeight))
+    private lazy var backwardProgressView = PaginatorView(frame: .init(x: 0,
+                                                                       y: 0,
+                                                                       width: collectionView.frame.width,
+                                                                       height: Constants.paginatorHeight))
 
     private lazy var adapter = collectionView.rddm.baseBuilder
         .add(plugin: .paginatable(progressView: forwardProgressView, output: self))
@@ -222,10 +227,10 @@ extension TwoDirectionPaginatableCollectionViewController: BackwardPaginatableOu
                 let finalOffset = CGPoint(x: 0, y: newContentHeight - initialContentHeight - Constants.paginatorHeight)
                 self.collectionView.setContentOffset(finalOffset, animated: false)
             } else {
-                    input?.updateProgress(isLoading: false)
-                    input?.updateError(SampleError.sample)
-                }
+                input?.updateProgress(isLoading: false)
+                input?.updateError(SampleError.sample)
             }
         }
+    }
 
 }

--- a/Example/ReactiveDataDisplayManager/Collection/TwoDirectionPaginatableCollectionViewController/TwoDirectionPaginatableCollectionViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Collection/TwoDirectionPaginatableCollectionViewController/TwoDirectionPaginatableCollectionViewController.swift
@@ -47,7 +47,6 @@ final class TwoDirectionPaginatableCollectionViewController: UIViewController {
     private var currentPage = 0
 
     private lazy var emptyCell = CollectionSpacerCell.rddm.baseGenerator(with: CollectionSpacerCell.Model(height: 0), and: .class)
-    private var currentFirstItem: CollectionCellGenerator?
 
     // MARK: - UIViewController
 
@@ -154,8 +153,6 @@ private extension TwoDirectionPaginatableCollectionViewController {
 
     func fillPrev() -> Bool {
         currentPage -= 1
-        // as the first item is an empty cell
-        currentFirstItem = adapter.sections.first?.generators[safe: 1]
 
         let newGenerators = (0...Constants.pageSize).map { _ in
             return makeGenerator()

--- a/Example/ReactiveDataDisplayManager/Collection/TwoDirectionPaginatableCollectionViewController/TwoDirectionPaginatableCollectionViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Collection/TwoDirectionPaginatableCollectionViewController/TwoDirectionPaginatableCollectionViewController.swift
@@ -1,0 +1,260 @@
+//
+//  TwoDirectionPaginatableCollectionViewController.swift
+//  ReactiveDataDisplayManager
+//
+//  Created by Антон Голубейков on 23.06.2023.
+//
+
+import UIKit
+import ReactiveDataDisplayManager
+import ReactiveDataComponents
+
+final class TwoDirectionPaginatableCollectionViewController: UIViewController {
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let pageSize = 20
+        static let paginatorHeight: CGFloat = 80
+        static let firstPageMiddleIndexPath = IndexPath(row: Constants.pageSize / 2, section: 0)
+    }
+
+    // MARK: - IBOutlet
+
+    @IBOutlet private weak var collectionView: UICollectionView!
+    @IBOutlet private weak var activityIndicator: UIActivityIndicatorView!
+
+    // MARK: - Private Properties
+
+    private lazy var forwardProgressView = PaginatorView(frame: .init(x: 0, y: 0, width: collectionView.frame.width, height: Constants.paginatorHeight))
+    private lazy var backwardProgressView = PaginatorView(frame: .init(x: 0, y: 0, width: collectionView.frame.width, height: Constants.paginatorHeight))
+    
+
+    private lazy var adapter = collectionView.rddm.baseBuilder
+        .add(plugin: .paginatable(progressView: forwardProgressView, output: self))
+        .add(plugin: .backwardPaginatable(progressView: backwardProgressView, output: self))
+        .build()
+
+    private weak var forwardPaginatableInput: PaginatableInput?
+    private weak var backwardPaginatableInput: PaginatableInput?
+
+    private var isFirstPageLoading = true
+    private var currentPage = 0
+
+    private lazy var emptyCell = CollectionSpacerCell.rddm.baseGenerator(with: CollectionSpacerCell.Model(height: 0), and: .class)
+    private var currentFirstItem: CollectionCellGenerator?
+
+    // MARK: - UIViewController
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Collection with two direction pagination"
+
+        configureActivityIndicatorIfNeeded()
+        loadFirstPage()
+    }
+
+}
+
+// MARK: - Configuration
+
+private extension TwoDirectionPaginatableCollectionViewController {
+
+    func configureActivityIndicatorIfNeeded() {
+        if #available(iOS 13.0, tvOS 13.0, *) {
+            activityIndicator.style = .medium
+        }
+    }
+
+}
+
+// MARK: - Private Methods
+
+private extension TwoDirectionPaginatableCollectionViewController {
+
+    func loadFirstPage() {
+
+        // show loader
+        activityIndicator.isHidden = false
+        activityIndicator.hidesWhenStopped = true
+        activityIndicator.startAnimating()
+
+        // hide footer
+        forwardPaginatableInput?.updatePagination(canIterate: false)
+        backwardPaginatableInput?.updatePagination(canIterate: false)
+        forwardPaginatableInput?.updateProgress(isLoading: false)
+        backwardPaginatableInput?.updateProgress(isLoading: false)
+
+        // imitation of loading first page
+        delay(.now() + .seconds(3)) { [weak self] in
+            // fill table
+            self?.fillAdapter()
+
+            // hide loader
+            self?.activityIndicator?.stopAnimating()
+
+            // scroll to middle
+            self?.collectionView.scrollToItem(at: Constants.firstPageMiddleIndexPath, at: .centeredVertically, animated: false)
+
+            // show pagination loader if update is needed
+            self?.forwardPaginatableInput?.updatePagination(canIterate: true)
+            self?.backwardPaginatableInput?.updatePagination(canIterate: true)
+        }
+    }
+
+    /// This method is used to fill adapter
+    func fillAdapter() {
+        adapter += emptyCell
+
+        for _ in 0...Constants.pageSize {
+            adapter += makeGenerator()
+        }
+
+        adapter => .reload
+    }
+
+    func makeGenerator() -> CollectionCellGenerator {
+        let title = "Random cell \(Int.random(in: 0...1000)) from page \(currentPage)"
+        return TitleCollectionViewCell.rddm.baseGenerator(with: title)
+    }
+
+    func canFillPages() -> Bool {
+        if isFirstPageLoading {
+            isFirstPageLoading.toggle()
+            return false
+        } else {
+            return true
+        }
+    }
+
+    func fillNext() -> Bool {
+        currentPage += 1
+
+        var newGenerators = [CollectionCellGenerator]()
+
+        for _ in 0...Constants.pageSize {
+            newGenerators.append(makeGenerator())
+        }
+
+        if let lastGenerator = adapter.sections.last?.generators.last {
+            adapter.insert(after: lastGenerator, new: newGenerators)
+        } else {
+            adapter += newGenerators
+            adapter => .reload
+        }
+
+        // pages count is infinite if it`s a single direction scroll
+        return currentPage != 0
+    }
+
+    func fillPrev() -> Bool {
+        currentPage -= 1
+        // as the first item is an empty cell
+        currentFirstItem = adapter.sections.first?.generators[safe: 1]
+
+        let newGenerators = (0...Constants.pageSize).map { _ in
+            return makeGenerator()
+        }
+        adapter.insert(after: emptyCell, new: newGenerators)
+
+        // pages count is infinite if it`s a single direction scroll
+        return currentPage != 0
+    }
+
+}
+
+// MARK: - PaginatableOutput
+
+extension TwoDirectionPaginatableCollectionViewController: PaginatableOutput {
+
+    func onPaginationInitialized(with input: PaginatableInput) {
+        forwardPaginatableInput = input
+    }
+
+    func loadNextPage(with input: PaginatableInput) {
+
+        input.updateProgress(isLoading: true)
+
+        delay(.now() + .seconds(3)) { [weak self, weak input] in
+            let canFillNext = self?.canFillPages() ?? false
+            if canFillNext {
+                let canIterate = self?.fillNext() ?? false
+
+                input?.updateProgress(isLoading: false)
+                input?.updatePagination(canIterate: canIterate)
+                self?.backwardPaginatableInput?.updatePagination(canIterate: canIterate)
+            } else {
+                input?.updateProgress(isLoading: false)
+                input?.updateError(SampleError.sample)
+            }
+        }
+    }
+
+}
+
+// MARK: - BackwardPaginatableOutput
+
+extension TwoDirectionPaginatableCollectionViewController: BackwardPaginatableOutput {
+
+    func onBackwardPaginationInitialized(with input: ReactiveDataDisplayManager.PaginatableInput) {
+        backwardPaginatableInput = input
+    }
+
+    func loadPrevPage(with input: ReactiveDataDisplayManager.PaginatableInput) {
+        input.updateProgress(isLoading: true)
+
+        delay(.now() + .seconds(2)) { [weak self, weak input] in
+            guard let self = self else {
+                return
+            }
+            if self.canFillPages() {
+                let canIterate = self.fillPrev()
+                input?.updateProgress(isLoading: false)
+                input?.updatePagination(canIterate: canIterate)
+                self.forwardPaginatableInput?.updatePagination(canIterate: canIterate)
+                
+                self.collectionView.scrollToItem(at: IndexPath(item: Constants.pageSize, section: 0), at: .top, animated: false)
+
+                //option 1
+//                let initialGeneratorsHeight = self.adapter.sections.first?.generators.reduce(0) {
+//                    if let cell = $1 as? CalculatableHeightCollectionCellGenerator<TitleCollectionViewCell> {
+//                        return ($0 + cell.getSize().height)
+//                    } else {
+//                        return $0
+//                    }
+//                }
+//option 2
+//                let initialContentHeight = self.collectionView.collectionViewLayout.collectionViewContentSize.height
+//
+//                let canIterate = self.fillPrev()
+//                input?.updateProgress(isLoading: false)
+//                input?.updatePagination(canIterate: canIterate)
+//                self.forwardPaginatableInput?.updatePagination(canIterate: canIterate)
+//option 1
+//                let newGeneratorsHeight = self.adapter.sections.first?.generators.reduce(0) {
+//                    if let cell = $1 as? CalculatableHeightCollectionCellGenerator<TitleCollectionViewCell> {
+//                        return ($0 + cell.getSize().height)
+//                    } else {
+//                        return $0
+//                    }
+//                }
+//
+//                if let initialGeneratorsHeight = initialGeneratorsHeight, let newGeneratorsHeight = newGeneratorsHeight {
+//                    let finalOffset = CGPoint(x: 0, y: newGeneratorsHeight - initialGeneratorsHeight)
+//                    self.collectionView.setContentOffset(finalOffset, animated: false)
+//                }
+//option 2
+
+//                self.view.layoutIfNeeded()
+//                let newContentHeight = self.collectionView.collectionViewLayout.collectionViewContentSize.height
+//
+//                let finalOffset = CGPoint(x: 0, y: initialContentHeight - newContentHeight)
+//                self.collectionView.setContentOffset(finalOffset, animated: false)
+            } else {
+                    input?.updateProgress(isLoading: false)
+                    input?.updateError(SampleError.sample)
+                }
+            }
+        }
+
+}

--- a/Example/ReactiveDataDisplayManager/Collection/Views/Cells/TitleCollectionViewCell/TitleCollectionViewCell.swift
+++ b/Example/ReactiveDataDisplayManager/Collection/Views/Cells/TitleCollectionViewCell/TitleCollectionViewCell.swift
@@ -60,6 +60,20 @@ extension TitleCollectionViewCell: HighlightableItem {
 
 }
 
+// MARK: - CalculatableHeightItem
+
+extension TitleCollectionViewCell: CalculatableHeightItem {
+
+    static func getHeight(forWidth width: CGFloat, with model: String) -> CGFloat {
+        let horizontalInsets: CGFloat = 32
+        let verticalInsets: CGFloat = 29
+        let titleHeight = model.getHeight(withConstrainedWidth: width - horizontalInsets,
+                                          font: .preferredFont(forTextStyle: .body))
+        return verticalInsets + titleHeight
+    }
+
+}
+
 // MARK: - Private
 
 private extension TitleCollectionViewCell {

--- a/Source/Collection/Manager/BaseCollectionManager.swift
+++ b/Source/Collection/Manager/BaseCollectionManager.swift
@@ -177,7 +177,8 @@ extension BaseCollectionManager {
 
 private extension BaseCollectionManager {
 
-    func insert(elements: [(generator: CollectionCellGenerator, sectionIndex: Int, generatorIndex: Int)], with animation: CollectionItemAnimation? = .animated) {
+    func insert(elements: [(generator: CollectionCellGenerator, sectionIndex: Int, generatorIndex: Int)],
+                with animation: CollectionItemAnimation? = .animated) {
 
         elements.forEach { [weak self] element in
             self?.sections[element.sectionIndex].generators.insert(element.generator, at: element.generatorIndex)

--- a/Source/Collection/Manager/BaseCollectionManager.swift
+++ b/Source/Collection/Manager/BaseCollectionManager.swift
@@ -144,13 +144,14 @@ extension BaseCollectionManager {
     ///   - after: Generator after which new generator will be added. Must be in the DDM.
     ///   - new: Generators which you want to insert after current generator.
     public func insert(after generator: CollectionCellGenerator,
-                       new newGenerators: [CollectionCellGenerator]) {
+                       new newGenerators: [CollectionCellGenerator],
+                       with animation: CollectionItemAnimation? = .animated) {
         guard let index = self.findGenerator(generator) else { return }
 
         let elements = newGenerators.enumerated().map { item in
             (item.element, index.sectionIndex, index.generatorIndex + item.offset + 1)
         }
-        self.insert(elements: elements)
+        self.insert(elements: elements, with: animation)
     }
 
     /// Removes generator from data display manager. Generators compares by references.
@@ -176,7 +177,7 @@ extension BaseCollectionManager {
 
 private extension BaseCollectionManager {
 
-    func insert(elements: [(generator: CollectionCellGenerator, sectionIndex: Int, generatorIndex: Int)]) {
+    func insert(elements: [(generator: CollectionCellGenerator, sectionIndex: Int, generatorIndex: Int)], with animation: CollectionItemAnimation? = .animated) {
 
         elements.forEach { [weak self] element in
             self?.sections[element.sectionIndex].generators.insert(element.generator, at: element.generatorIndex)
@@ -187,7 +188,7 @@ private extension BaseCollectionManager {
         }
 
         sections.registerAllIfNeeded(with: view, using: registrator)
-        modifier?.insertRows(at: indexPaths, with: .animated)
+        modifier?.insertRows(at: indexPaths, with: animation ?? .none)
     }
 
     func findGenerator(_ generator: CollectionCellGenerator) -> (sectionIndex: Int, generatorIndex: Int)? {

--- a/Source/Collection/Plugins/PluginAction/CollectionBackwardPaginatablePlugin.swift
+++ b/Source/Collection/Plugins/PluginAction/CollectionBackwardPaginatablePlugin.swift
@@ -1,0 +1,114 @@
+//
+//  CollectionBackwardPaginatablePlugin.swift
+//  ReactiveDataDisplayManager
+//
+//  Created by Антон Голубейков on 23.06.2023.
+//
+
+import UIKit
+
+/// Plugin to display `progressView` while prevous page is loading
+///
+/// Show `progressView` on `willDisplay` first cell.
+/// Hide `progressView` when finish loading request
+///
+/// - Warning: Specify itemSize of your layout to proper `willDisplay` calls and correct `contentSize`
+public class CollectionBackwardPaginatablePlugin: BaseCollectionPlugin<CollectionEvent> {
+
+    // MARK: - Nested types
+
+    public typealias ProgressView = UIView & ProgressDisplayableItem
+
+    // MARK: - Private Properties
+
+    private let progressView: ProgressView
+    private weak var output: BackwardPaginatableOutput?
+
+    private var isLoading = false
+
+    private weak var collectionView: UICollectionView?
+
+    /// Property which indicating availability of pages
+    public private(set) var canIterate = false {
+        didSet {
+            if canIterate {
+                guard progressView.superview == nil else {
+                    return
+                }
+
+                collectionView?.addSubview(progressView)
+                collectionView?.contentInset.top += progressView.frame.height
+            } else {
+                guard progressView.superview != nil else {
+                    return
+                }
+
+                progressView.removeFromSuperview()
+                collectionView?.contentInset.top -= progressView.frame.height
+            }
+        }
+    }
+
+    // MARK: - Initialization
+
+    /// - parameter progressView: indicator view to add inside header. Do not forget to init this view with valid frame size.
+    /// - parameter output: output signals to hide  `progressView` from header
+    init(progressView: ProgressView, with output: BackwardPaginatableOutput) {
+        self.progressView = progressView
+        self.output = output
+    }
+
+    // MARK: - BaseTablePlugin
+
+    public override func setup(with manager: BaseCollectionManager?) {
+        collectionView = manager?.view
+        canIterate = false
+        output?.onBackwardPaginationInitialized(with: self)
+        self.progressView.setOnRetry { [weak self] in
+            guard let input = self, let output = self?.output else {
+                return
+            }
+            output.loadPrevPage(with: input)
+        }
+    }
+
+    public override func process(event: CollectionEvent, with manager: BaseCollectionManager?) {
+
+        switch event {
+        case .willDisplayCell(let indexPath):
+            let firstCellIndexPath = IndexPath(row: 0, section: 0)
+            guard indexPath == firstCellIndexPath, canIterate, !isLoading else {
+                return
+            }
+
+            // Hack: Update progressView position. Imitation of global header view like `tableFooterView`
+
+            progressView.frame = .init(origin: .init(x: progressView.frame.origin.x, y: 0),
+                                       size: progressView.frame.size)
+
+            output?.loadPrevPage(with: self)
+        default:
+            break
+        }
+    }
+
+}
+
+// MARK: - PaginatableInput
+
+extension CollectionBackwardPaginatablePlugin: PaginatableInput {
+
+    public func updateProgress(isLoading: Bool) {
+        self.isLoading = isLoading
+        progressView.showProgress(isLoading)
+    }
+
+    public func updateError(_ error: Error?) {
+        progressView.showError(error)
+    }
+
+    public func updatePagination(canIterate: Bool) {
+        self.canIterate = canIterate
+    }
+
+}

--- a/Source/Collection/Plugins/PluginAction/CollectionBackwardPaginatablePlugin.swift
+++ b/Source/Collection/Plugins/PluginAction/CollectionBackwardPaginatablePlugin.swift
@@ -81,9 +81,9 @@ public class CollectionBackwardPaginatablePlugin: BaseCollectionPlugin<Collectio
                 return
             }
 
-            // Hack: Update progressView position. Imitation of global header view like `tableFooterView`
+            // Hack: Update progressView position. Imitation of global header view like `tableHeaderView`
 
-            progressView.frame = .init(origin: .init(x: progressView.frame.origin.x, y: 0),
+            progressView.frame = .init(origin: .init(x: progressView.frame.origin.x, y: -progressView.frame.height),
                                        size: progressView.frame.size)
 
             output?.loadPrevPage(with: self)

--- a/Source/Collection/Plugins/PluginAction/CollectionPaginatablePlugin.swift
+++ b/Source/Collection/Plugins/PluginAction/CollectionPaginatablePlugin.swift
@@ -136,4 +136,17 @@ public extension BaseCollectionPlugin {
         .init(progressView: progressView, with: output)
     }
 
+    /// Plugin to display `progressView` while previous page is loading
+    ///
+    /// Show `progressView` on `willDisplay` first cell.
+    /// Hide `progressView` when finish loading request
+    ///
+    /// - parameter progressView: indicator view to add inside header. Do not forget to init this view with valid frame size.
+    /// - parameter output: output signals to hide  `progressView` from header
+    static func backwardPaginatable(progressView: CollectionBackwardPaginatablePlugin.ProgressView,
+                                    output: BackwardPaginatableOutput) -> CollectionBackwardPaginatablePlugin {
+        return CollectionBackwardPaginatablePlugin(progressView: progressView, with: output)
+
+    }
+
 }

--- a/Source/Collection/Plugins/PluginAction/CollectionPaginatablePlugin.swift
+++ b/Source/Collection/Plugins/PluginAction/CollectionPaginatablePlugin.swift
@@ -25,7 +25,7 @@ public class CollectionPaginatablePlugin: BaseCollectionPlugin<CollectionEvent> 
     private let progressView: ProgressView
     private weak var output: PaginatableOutput?
 
-    private var isLoading: Bool = false
+    private var isLoading = false
 
     private weak var collectionView: UICollectionView?
 


### PR DESCRIPTION
## [SPT-1364](https://jira.surfstudio.ru/browse/SPT-1364)
## Что сделано?

- Добавил CollectionBackwardPaginatablePlugin для пагинации при скролле вверх (ранее была пагинация только для скролла вниз)
- Добавил в example-проект TwoDirectionPaginatableCollectionViewController, который реализует оба плагина для пагинации 

## Зачем это сделано?

Добавить новые возможности для библиотеки. Как пример, обратная пагинация может использоваться в чатах. 

## На что обратить внимание
При обратной пагинации (если скроллить наверх), при после вставки новых ячеек в начало, сбивается позиция изнального скролла примерно на 20 единиц. В таблице получилось пофиксить это сменив стиль с Grouped на Plain. В коллекции такого нет. Поэтому поищу целевое решение в рамках https://jira.surfstudio.ru/browse/SPT-1514 . При чем эта проблема актуальна только для второй страницы скролла. Дальнейшие страницы грузятся с корректным возвратом на изначальную позицию скролла. 

## Как протестировать?
Чтобы воспроизвести проблему надо:
Зайти в Collection -> Collection with two direction pagination -> Проскроллить вверх. 

<details><summary>Демо</summary>

https://github.com/surfstudio/ReactiveDataDisplayManager/assets/47087482/017ba0b4-7532-43c8-8eac-b01140b1f5bf



</details>
