### PR TITLE
Hotfix/spt 1546/insert func optimisation

### DIFF
--- a/Example/ReactiveDataDisplayManager/Table/AllPluginsTableViewController/AllPluginsTableViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Table/AllPluginsTableViewController/AllPluginsTableViewController.swift
@@ -97,12 +97,31 @@ private extension AllPluginsTableViewController {
         addPrefetcherableSection()
 
         // Tell adapter that we've changed generators
-        adapter.forceRefill()
+        adapter.forceRefill { [weak self] in
+            self?.insertMoreSections()
+        }
     }
 
     func updateBarButtonItem(with title: String) {
         let button = UIBarButtonItem(title: title, style: .plain, target: self, action: #selector(changeTableEditing))
         navigationItem.rightBarButtonItem = button
+    }
+
+    /// Insertion of new section with some cells
+    func insertMoreSections() {
+
+        guard let lastSectionGenerator = adapter.sections.last else {
+            return
+        }
+
+        // Create generators
+        let newHeaderGenerator = SectionTitleHeaderGenerator(model: "One more section", needSectionIndexTitle: true)
+        let generators = Constants.titles.map { TitleTableViewCell.rddm.baseGenerator(with: $0) }
+
+        // Insert them
+        adapter.insertSection(after: lastSectionGenerator,
+                              new: newHeaderGenerator,
+                              generators: generators)
     }
 
     /// Use this method for UI stress test only.

--- a/Example/ReactiveDataDisplayManager/Table/AllPluginsTableViewController/AllPluginsTableViewController.swift
+++ b/Example/ReactiveDataDisplayManager/Table/AllPluginsTableViewController/AllPluginsTableViewController.swift
@@ -110,7 +110,7 @@ private extension AllPluginsTableViewController {
     /// Insertion of new section with some cells
     func insertMoreSections() {
 
-        guard let lastSectionGenerator = adapter.sections.last else {
+        guard let existingSectionGenerator = adapter.sections.last else {
             return
         }
 
@@ -119,7 +119,7 @@ private extension AllPluginsTableViewController {
         let generators = Constants.titles.map { TitleTableViewCell.rddm.baseGenerator(with: $0) }
 
         // Insert them
-        adapter.insertSection(after: lastSectionGenerator,
+        adapter.insertSection(after: existingSectionGenerator,
                               new: newHeaderGenerator,
                               generators: generators)
     }

--- a/ReactiveDataDisplayManagerTests/Mocks/AutoMockable.generated.swift
+++ b/ReactiveDataDisplayManagerTests/Mocks/AutoMockable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 1.9.2 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.0.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 // swiftlint:disable all
 

--- a/Source/Collection/Manager/BaseCollectionManager.swift
+++ b/Source/Collection/Manager/BaseCollectionManager.swift
@@ -223,11 +223,18 @@ private extension BaseCollectionManager {
             self?.generators[element.sectionIndex].insert(element.generator, at: element.generatorIndex)
         }
 
-        let indexPaths = elements.map {
-            IndexPath(row: $0.generatorIndex, section: $0.sectionIndex)
+        let indexDictionary = elements.reduce([Int: [IndexPath]]()) { result, value in
+            var result = result
+            let indexPath = IndexPath(item: value.generatorIndex, section: value.sectionIndex)
+            if result[value.sectionIndex] == nil {
+                result[value.sectionIndex] = [indexPath]
+            } else {
+                result[value.sectionIndex]?.append(indexPath)
+            }
+            return result
         }
 
-        modifier?.insertRows(at: indexPaths, with: .animated)
+        modifier?.insertSectionsAndRows(at: indexDictionary, with: .animated)
     }
 
     func findGenerator(_ generator: CollectionCellGenerator) -> (sectionIndex: Int, generatorIndex: Int)? {

--- a/Source/Collection/Manager/BaseCollectionManager.swift
+++ b/Source/Collection/Manager/BaseCollectionManager.swift
@@ -227,18 +227,9 @@ private extension BaseCollectionManager {
             }
         }
 
-        let indexDictionary = elements.reduce([Int: [IndexPath]]()) { result, value in
-            var result = result
-            let indexPath = IndexPath(item: value.generatorIndex, section: value.sectionIndex)
-            if result[value.sectionIndex] == nil {
-                result[value.sectionIndex] = [indexPath]
-            } else {
-                result[value.sectionIndex]?.append(indexPath)
-            }
-            return result
-        }
+        let indexPaths = elements.map { IndexPath(item: $0.generatorIndex, section: $0.sectionIndex) }
 
-        modifier?.insertSectionsAndRows(at: indexDictionary, with: .animated)
+        modifier?.insertRows(at: indexPaths, with: .animated)
     }
 
     func findGenerator(_ generator: CollectionCellGenerator) -> (sectionIndex: Int, generatorIndex: Int)? {

--- a/Source/Collection/Manager/BaseCollectionManager.swift
+++ b/Source/Collection/Manager/BaseCollectionManager.swift
@@ -220,7 +220,11 @@ private extension BaseCollectionManager {
 
         elements.forEach { [weak self] element in
             element.generator.registerCell(in: view)
-            self?.generators[element.sectionIndex].insert(element.generator, at: element.generatorIndex)
+            if self?.generators.count == element.sectionIndex {
+                self?.generators.append([element.generator])
+            } else {
+                self?.generators[element.sectionIndex].insert(element.generator, at: element.generatorIndex)
+            }
         }
 
         let indexDictionary = elements.reduce([Int: [IndexPath]]()) { result, value in

--- a/Source/Collection/Modifier/CollectionCommonModifier.swift
+++ b/Source/Collection/Modifier/CollectionCommonModifier.swift
@@ -87,6 +87,8 @@ class CollectionCommonModifier: Modifier<UICollectionView, CollectionItemAnimati
     ///
     /// - parameter indexDictionary: dictionary where **key** is new section index and value is location of items to insert
     /// - parameter insertAnimation: animation of insert operation
+    ///  - Warning: make sure that you do not have mistake in indexes inside `indexDictionary`.
+    ///  For example, if you are inserting **many sections** using this method you should notice that **index** cannot be greater than **final number of sections**.
     override func insertSectionsAndRows(at indexDictionary: [Int: [IndexPath]],
                                         with insertAnimation: CollectionItemAnimation?) {
         guard let view = view else { return }

--- a/Source/Collection/Modifier/CollectionCommonModifier.swift
+++ b/Source/Collection/Modifier/CollectionCommonModifier.swift
@@ -87,16 +87,13 @@ class CollectionCommonModifier: Modifier<UICollectionView, CollectionItemAnimati
     ///
     /// - parameter indexDictionary: dictionary where **key** is new section index and value is location of items to insert
     /// - parameter insertAnimation: animation of insert operation
-    override func insertSectionsAndRows(at indexDictionary: [Int : [IndexPath]],
+    override func insertSectionsAndRows(at indexDictionary: [Int: [IndexPath]],
                                         with insertAnimation: CollectionItemAnimation?) {
         guard let view = view else { return }
         animator?.perform(in: view, animated: insertAnimation != nil) { [weak view] in
-            let numberOfSections = view?.numberOfSections ?? 0
-            let setOfKeys = IndexSet(indexDictionary.keys.filter { $0 >= numberOfSections })
+            let setOfKeys = IndexSet(indexDictionary.keys)
             let allValues = indexDictionary.values.flatMap { $0 }
-            if !setOfKeys.isEmpty {
-                view?.insertSections(setOfKeys)
-            }
+            view?.insertSections(setOfKeys)
             view?.insertItems(at: allValues)
         }
     }

--- a/Source/Collection/Modifier/CollectionCommonModifier.swift
+++ b/Source/Collection/Modifier/CollectionCommonModifier.swift
@@ -83,10 +83,29 @@ class CollectionCommonModifier: Modifier<UICollectionView, CollectionItemAnimati
         }
     }
 
+    /// Insert new sections with items at specific position with animation
+    ///
+    /// - parameter indexDictionary: dictionary where **key** is new section index and value is location of items to insert
+    /// - parameter insertAnimation: animation of insert operation
+    override func insertSectionsAndRows(at indexDictionary: [Int : [IndexPath]],
+                                        with insertAnimation: CollectionItemAnimation?) {
+        guard let view = view else { return }
+        animator?.perform(in: view, animated: insertAnimation != nil) { [weak view] in
+            let numberOfSections = view?.numberOfSections ?? 0
+            let setOfKeys = IndexSet(indexDictionary.keys.filter { $0 >= numberOfSections })
+            let allValues = indexDictionary.values.flatMap { $0 }
+            if !setOfKeys.isEmpty {
+                view?.insertSections(setOfKeys)
+            }
+            view?.insertItems(at: allValues)
+        }
+    }
+
     /// Insert sections with animation
     ///
     /// - parameter indexPaths: indexes of inserted sections
     /// - parameter insertAnimation: animation of inserted sections
+    ///  - Warning: This method will insert an **empty** section only. If you need to insert section with items use `insertSectionsAndRows` instead.
     override func insertSections(at indexPaths: IndexSet, with insertAnimation: CollectionItemAnimation?) {
         guard let view = view else { return }
         animator?.perform(in: view, animated: insertAnimation != nil) { [weak view] in

--- a/Source/Collection/Modifier/CollectionDiffableModifier.swift
+++ b/Source/Collection/Modifier/CollectionDiffableModifier.swift
@@ -86,6 +86,17 @@ class CollectionDiffableModifier: Modifier<UICollectionView, CollectionItemAnima
         apply(animated: animation != nil)
     }
 
+    /// Insert new sections with items at specific position with animation
+    ///
+    /// - parameter indexDictionary: **ignored**, automatically calculated using `DiffableSnapshot`
+    /// - parameter insertAnimation:
+    ///     - **allowed** nil to disable animation
+    ///     - **ignored** any other, because automatically selected by `UICollectionViewDiffableDataSource`
+    override func insertSectionsAndRows(at indexDictionary: [Int : [IndexPath]],
+                                        with insertAnimation: CollectionItemAnimation?) {
+        apply(animated: insertAnimation != nil)
+    }
+
     /// Update snapshot after sections inserted
     ///
     /// - parameter indexPaths: **ignored**, automatically calculated using `DiffableSnapshot`

--- a/Source/Collection/Modifier/CollectionDiffableModifier.swift
+++ b/Source/Collection/Modifier/CollectionDiffableModifier.swift
@@ -92,7 +92,7 @@ class CollectionDiffableModifier: Modifier<UICollectionView, CollectionItemAnima
     /// - parameter insertAnimation:
     ///     - **allowed** nil to disable animation
     ///     - **ignored** any other, because automatically selected by `UICollectionViewDiffableDataSource`
-    override func insertSectionsAndRows(at indexDictionary: [Int : [IndexPath]],
+    override func insertSectionsAndRows(at indexDictionary: [Int: [IndexPath]],
                                         with insertAnimation: CollectionItemAnimation?) {
         apply(animated: insertAnimation != nil)
     }

--- a/Source/Protocols/Modifier/Modifier.swift
+++ b/Source/Protocols/Modifier/Modifier.swift
@@ -60,10 +60,19 @@ open class Modifier<View: UIView, Animation> {
         preconditionFailure("\(#function) must be overriden in child")
     }
 
+    /// Insert new sections with rows at specific position with animation
+    ///
+    /// - parameter indexDictionary: dictionary where **key** is new section index and value is location of subviews to insert
+    /// - parameter insertAnimation: animation of insert operation
+    open func insertSectionsAndRows(at indexDictionary: [Int : [IndexPath]], with insertAnimation: Animation?) {
+        preconditionFailure("\(#function) must be overriden in child")
+    }
+
     /// Insert new sections at specific position with animation
     ///
     /// - parameter indexPaths: location of sections to insert
     /// - parameter insertAnimation: animation of insert operation
+    ///  - Warning: This method will insert an **empty** section only. If you need to insert section with rows use `insertSectionsAndRows: [Int : [IndexPath]]` instead.
     open func insertSections(at indexPaths: IndexSet, with insertAnimation: Animation?) {
         preconditionFailure("\(#function) must be overriden in child")
     }

--- a/Source/Protocols/Modifier/Modifier.swift
+++ b/Source/Protocols/Modifier/Modifier.swift
@@ -64,6 +64,8 @@ open class Modifier<View: UIView, Animation> {
     ///
     /// - parameter indexDictionary: dictionary where **key** is new section index and value is location of subviews to insert
     /// - parameter insertAnimation: animation of insert operation
+    ///  - Warning: make sure that you do not have mistake in indexes inside `indexDictionary`.
+    ///  For example, if you are inserting **many sections** using this method you should notice that **index** cannot be greater than **final number of sections**.
     open func insertSectionsAndRows(at indexDictionary: [Int: [IndexPath]], with insertAnimation: Animation?) {
         preconditionFailure("\(#function) must be overriden in child")
     }

--- a/Source/Protocols/Modifier/Modifier.swift
+++ b/Source/Protocols/Modifier/Modifier.swift
@@ -64,7 +64,7 @@ open class Modifier<View: UIView, Animation> {
     ///
     /// - parameter indexDictionary: dictionary where **key** is new section index and value is location of subviews to insert
     /// - parameter insertAnimation: animation of insert operation
-    open func insertSectionsAndRows(at indexDictionary: [Int : [IndexPath]], with insertAnimation: Animation?) {
+    open func insertSectionsAndRows(at indexDictionary: [Int: [IndexPath]], with insertAnimation: Animation?) {
         preconditionFailure("\(#function) must be overriden in child")
     }
 

--- a/Source/Table/Manager/BaseTableManager.swift
+++ b/Source/Table/Manager/BaseTableManager.swift
@@ -192,7 +192,11 @@ extension BaseTableManager {
 
         elements.forEach { [weak self] element in
             element.generator.registerCell(in: view)
-            self?.generators[element.sectionIndex].insert(element.generator, at: element.generatorIndex)
+            if self?.generators.count == element.sectionIndex {
+                self?.generators.append([element.generator])
+            } else {
+                self?.generators[element.sectionIndex].insert(element.generator, at: element.generatorIndex)
+            }
         }
 
         let indexDictionary = elements.reduce([Int: [IndexPath]]()) { result, value in

--- a/Source/Table/Manager/BaseTableManager.swift
+++ b/Source/Table/Manager/BaseTableManager.swift
@@ -192,25 +192,12 @@ extension BaseTableManager {
 
         elements.forEach { [weak self] element in
             element.generator.registerCell(in: view)
-            if self?.generators.count == element.sectionIndex {
-                self?.generators.append([element.generator])
-            } else {
-                self?.generators[element.sectionIndex].insert(element.generator, at: element.generatorIndex)
-            }
+            self?.generators[element.sectionIndex].insert(element.generator, at: element.generatorIndex)
         }
 
-        let indexDictionary = elements.reduce([Int: [IndexPath]]()) { result, value in
-            var result = result
-            let indexPath = IndexPath(row: value.generatorIndex, section: value.sectionIndex)
-            if result[value.sectionIndex] == nil {
-                result[value.sectionIndex] = [indexPath]
-            } else {
-                result[value.sectionIndex]?.append(indexPath)
-            }
-            return result
-        }
+        let indexPaths = elements.map { IndexPath(row: $0.generatorIndex, section: $0.sectionIndex) }
 
-        modifier?.insertSectionsAndRows(at: indexDictionary, with: animation.value)
+        modifier?.insertRows(at: indexPaths, with: animation.value)
     }
 
     func insertManual(after generator: TableCellGenerator,

--- a/Source/Table/Manager/BaseTableManager.swift
+++ b/Source/Table/Manager/BaseTableManager.swift
@@ -195,11 +195,18 @@ extension BaseTableManager {
             self?.generators[element.sectionIndex].insert(element.generator, at: element.generatorIndex)
         }
 
-        let indexPaths = elements.map {
-            IndexPath(row: $0.generatorIndex, section: $0.sectionIndex)
+        let indexDictionary = elements.reduce([Int: [IndexPath]]()) { result, value in
+            var result = result
+            let indexPath = IndexPath(row: value.generatorIndex, section: value.sectionIndex)
+            if result[value.sectionIndex] == nil {
+                result[value.sectionIndex] = [indexPath]
+            } else {
+                result[value.sectionIndex]?.append(indexPath)
+            }
+            return result
         }
 
-        modifier?.insertRows(at: indexPaths, with: animation.value)
+        modifier?.insertSectionsAndRows(at: indexDictionary, with: animation.value)
     }
 
     func insertManual(after generator: TableCellGenerator,

--- a/Source/Table/Manager/ManualTableManager.swift
+++ b/Source/Table/Manager/ManualTableManager.swift
@@ -124,13 +124,8 @@ public class ManualTableManager: BaseTableManager {
                      generators: [TableCellGenerator],
                      with animation: TableRowAnimation = .animated(.automatic)) {
         let headerIndex = min(max(headerIndex, 0), self.sections.count)
-        self.sections.insert(headGenerator, at: headerIndex)
 
-        let elements = generators.enumerated().map {
-            ($0.element, headerIndex, $0.offset)
-        }
-
-        self.insert(elements: elements, with: animation)
+        self.insert(header: headGenerator, generators: generators, at: headerIndex, with: animation)
     }
 
     /// Inserts new section.
@@ -146,13 +141,8 @@ public class ManualTableManager: BaseTableManager {
                             with animation: TableRowAnimation = .animated(.automatic)) {
 
         let headerIndex = getIndexOf(headGenerator: sectionHeader, before: headerGenerator)
-        self.sections.insert(sectionHeader, at: headerIndex)
 
-        let elements = generators.enumerated().map {
-            ($0.element, headerIndex, $0.offset)
-        }
-
-        self.insert(elements: elements, with: animation)
+        self.insert(header: sectionHeader, generators: generators, at: headerIndex, with: animation)
     }
 
     /// Inserts new section.
@@ -167,13 +157,8 @@ public class ManualTableManager: BaseTableManager {
                             generators: [TableCellGenerator],
                             with animation: TableRowAnimation = .animated(.automatic)) {
         let headerIndex = getIndexOf(headGenerator: sectionHeader, after: headerGenerator)
-        self.sections.insert(sectionHeader, at: headerIndex)
 
-        let elements = generators.enumerated().map { item in
-            (item.element, headerIndex, item.offset)
-        }
-
-        self.insert(elements: elements, with: animation)
+        self.insert(header: sectionHeader, generators: generators, at: headerIndex, with: animation)
     }
 
     /// Inserts new generators after provided generator.
@@ -498,6 +483,19 @@ private extension ManualTableManager {
         self.generators.insert([], at: index)
 
         modifier?.insertSections(at: [index], with: animation.value)
+    }
+
+    func insert(header: TableHeaderGenerator,
+                generators: [TableCellGenerator],
+                at sectionIndex: Int,
+                with animation: TableRowAnimation) {
+
+        self.sections.insert(header, at: sectionIndex)
+        self.generators.insert(generators, at: sectionIndex)
+
+        let indexPaths = generators.enumerated().map { IndexPath(row: $0.offset, section: sectionIndex) }
+
+        modifier?.insertSectionsAndRows(at: [sectionIndex: indexPaths], with: animation.value)
     }
 
 }

--- a/Source/Table/Manager/ManualTableManager.swift
+++ b/Source/Table/Manager/ManualTableManager.swift
@@ -41,13 +41,7 @@ public class ManualTableManager: BaseTableManager {
     ///   - headGenerator: TableHeaderGenerator which you want to insert.
     ///   - after: TableHeaderGenerator, after which new TableHeaderGenerator will be added.
     open func insert(headGenerator: TableHeaderGenerator, after: TableHeaderGenerator) {
-        if self.sections.contains(where: { $0 === headGenerator }) {
-            fatalError("Error adding TableHeaderGenerator generator. TableHeaderGenerator generator was added earlier")
-        }
-        guard let anchorIndex = self.sections.firstIndex(where: { $0 === after }) else {
-            fatalError("Error adding TableHeaderGenerator generator. You tried to add generators after unexisted generator")
-        }
-        let newIndex = anchorIndex + 1
+        let newIndex = getIndexOf(headGenerator: headGenerator, after: after)
         self.insert(headGenerator: headGenerator, by: newIndex, animation: .notAnimated)
     }
 
@@ -57,13 +51,7 @@ public class ManualTableManager: BaseTableManager {
     ///   - headGenerator: TableHeaderGenerator which you want to insert.
     ///   - after: TableHeaderGenerator, before which new TableHeaderGenerator will be added.
     open func insert(headGenerator: TableHeaderGenerator, before: TableHeaderGenerator) {
-        if self.sections.contains(where: { $0 === headGenerator }) {
-            fatalError("Error adding TableHeaderGenerator generator. TableHeaderGenerator generator was added earlier")
-        }
-        guard let anchorIndex = self.sections.firstIndex(where: { $0 === before }) else {
-            fatalError("Error adding TableHeaderGenerator generator. You tried to add generators after unexisted generator")
-        }
-        let newIndex = max(anchorIndex - 1, 0)
+        let newIndex = getIndexOf(headGenerator: headGenerator, before: before)
         self.insert(headGenerator: headGenerator, by: newIndex, animation: .notAnimated)
     }
 
@@ -135,7 +123,7 @@ public class ManualTableManager: BaseTableManager {
                      by headerIndex: Int,
                      generators: [TableCellGenerator],
                      with animation: TableRowAnimation = .animated(.automatic)) {
-        let index = min(max(headerIndex, 0), self.sections.count)
+        let headerIndex = min(max(headerIndex, 0), self.sections.count)
         self.sections.insert(headGenerator, at: headerIndex)
 
         let elements = generators.enumerated().map {
@@ -156,13 +144,8 @@ public class ManualTableManager: BaseTableManager {
                             new sectionHeader: TableHeaderGenerator,
                             generators: [TableCellGenerator],
                             with animation: TableRowAnimation = .animated(.automatic)) {
-        self.insert(headGenerator: sectionHeader, before: headerGenerator)
 
-        guard let headerIndex = self.sections.firstIndex(where: {
-            $0 === sectionHeader
-        }) else {
-            return
-        }
+        let headerIndex = getIndexOf(headGenerator: sectionHeader, before: headerGenerator)
 
         let elements = generators.enumerated().map {
             ($0.element, headerIndex, $0.offset)
@@ -182,13 +165,7 @@ public class ManualTableManager: BaseTableManager {
                             new sectionHeader: TableHeaderGenerator,
                             generators: [TableCellGenerator],
                             with animation: TableRowAnimation = .animated(.automatic)) {
-        self.insert(headGenerator: sectionHeader, after: headerGenerator)
-
-        guard let headerIndex = self.sections.firstIndex(where: {
-            $0 === sectionHeader
-        }) else {
-            return
-        }
+        let headerIndex = getIndexOf(headGenerator: sectionHeader, after: headerGenerator)
 
         let elements = generators.enumerated().map { item in
             (item.element, headerIndex, item.offset)
@@ -491,7 +468,25 @@ public class ManualTableManager: BaseTableManager {
 
 private extension ManualTableManager {
 
-    // MARK: - Private methods
+    func getIndexOf(headGenerator: TableHeaderGenerator, after: TableHeaderGenerator) -> Int {
+        if self.sections.contains(where: { $0 === headGenerator }) {
+            fatalError("Error adding TableHeaderGenerator generator. TableHeaderGenerator generator was added earlier")
+        }
+        guard let anchorIndex = self.sections.firstIndex(where: { $0 === after }) else {
+            fatalError("Error adding TableHeaderGenerator generator. You tried to add generators after unexisted generator")
+        }
+        return anchorIndex + 1
+    }
+
+    func getIndexOf(headGenerator: TableHeaderGenerator, before: TableHeaderGenerator) -> Int {
+        if self.sections.contains(where: { $0 === headGenerator }) {
+            fatalError("Error adding TableHeaderGenerator generator. TableHeaderGenerator generator was added earlier")
+        }
+        guard let anchorIndex = self.sections.firstIndex(where: { $0 === before }) else {
+            fatalError("Error adding TableHeaderGenerator generator. You tried to add generators before unexisted generator")
+        }
+        return max(anchorIndex - 1, 0)
+    }
 
     func insert(headGenerator: TableHeaderGenerator,
                 by index: Int,

--- a/Source/Table/Manager/ManualTableManager.swift
+++ b/Source/Table/Manager/ManualTableManager.swift
@@ -314,14 +314,10 @@ public class ManualTableManager: BaseTableManager {
                      by headerIndex: Int,
                      generators: [TableCellGenerator],
                      with animation: UITableView.RowAnimation) {
-        let index = min(max(headerIndex, 0), self.sections.count)
-        self.sections.insert(headGenerator, at: headerIndex)
-
-        let elements = generators.enumerated().map {
-            ($0.element, headerIndex, $0.offset)
-        }
-
-        self.insert(elements: elements, with: .animated(animation))
+        self.insert(headGenerator: headGenerator,
+                    by: headerIndex,
+                    generators: generators,
+                    with: .animated(animation))
     }
 
     @available(*, deprecated, message: "Please use method with a new `TableRowAnimation` parameter")
@@ -329,19 +325,10 @@ public class ManualTableManager: BaseTableManager {
                             new sectionHeader: TableHeaderGenerator,
                             generators: [TableCellGenerator],
                             with animation: UITableView.RowAnimation) {
-        self.insert(headGenerator: sectionHeader, before: headerGenerator)
-
-        guard let headerIndex = self.sections.firstIndex(where: {
-            $0 === sectionHeader
-        }) else {
-            return
-        }
-
-        let elements = generators.enumerated().map {
-            ($0.element, headerIndex, $0.offset)
-        }
-
-        self.insert(elements: elements, with: .animated(animation))
+        self.insertSection(before: headerGenerator,
+                           new: sectionHeader,
+                           generators: generators,
+                           with: .animated(animation))
     }
 
     @available(*, deprecated, message: "Please use method with a new `TableRowAnimation` parameter")
@@ -349,19 +336,11 @@ public class ManualTableManager: BaseTableManager {
                             new sectionHeader: TableHeaderGenerator,
                             generators: [TableCellGenerator],
                             with animation: UITableView.RowAnimation) {
-        self.insert(headGenerator: sectionHeader, after: headerGenerator)
 
-        guard let headerIndex = self.sections.firstIndex(where: {
-            $0 === sectionHeader
-        }) else {
-            return
-        }
-
-        let elements = generators.enumerated().map { item in
-            (item.element, headerIndex, item.offset)
-        }
-
-        self.insert(elements: elements, with: .animated(animation))
+        self.insertSection(after: headerGenerator,
+                           new: sectionHeader,
+                           generators: generators,
+                           with: .animated(animation))
     }
 
     @available(*, deprecated, message: "Please use method with a new `TableRowAnimation` parameter")

--- a/Source/Table/Manager/ManualTableManager.swift
+++ b/Source/Table/Manager/ManualTableManager.swift
@@ -132,13 +132,11 @@ public class ManualTableManager: BaseTableManager {
     ///   - generators: Generators which you want to insert.
     ///   - with: Animation for row action.
     open func insert(headGenerator: TableHeaderGenerator,
-                     by index: Int,
+                     by headerIndex: Int,
                      generators: [TableCellGenerator],
                      with animation: TableRowAnimation = .animated(.automatic)) {
-        self.insert(headGenerator: headGenerator, by: index, animation: animation)
-        guard let headerIndex = self.sections.firstIndex(where: { $0 === headGenerator }) else {
-            return
-        }
+        let index = min(max(headerIndex, 0), self.sections.count)
+        self.sections.insert(headGenerator, at: headerIndex)
 
         let elements = generators.enumerated().map {
             ($0.element, headerIndex, $0.offset)
@@ -349,13 +347,11 @@ public class ManualTableManager: BaseTableManager {
 
     @available(*, deprecated, message: "Please use method with a new `TableRowAnimation` parameter")
     open func insert(headGenerator: TableHeaderGenerator,
-                     by index: Int,
+                     by headerIndex: Int,
                      generators: [TableCellGenerator],
                      with animation: UITableView.RowAnimation) {
-        self.insert(headGenerator: headGenerator, by: index, animation: .animated(animation))
-        guard let headerIndex = self.sections.firstIndex(where: { $0 === headGenerator }) else {
-            return
-        }
+        let index = min(max(headerIndex, 0), self.sections.count)
+        self.sections.insert(headGenerator, at: headerIndex)
 
         let elements = generators.enumerated().map {
             ($0.element, headerIndex, $0.offset)

--- a/Source/Table/Manager/ManualTableManager.swift
+++ b/Source/Table/Manager/ManualTableManager.swift
@@ -146,6 +146,7 @@ public class ManualTableManager: BaseTableManager {
                             with animation: TableRowAnimation = .animated(.automatic)) {
 
         let headerIndex = getIndexOf(headGenerator: sectionHeader, before: headerGenerator)
+        self.sections.insert(sectionHeader, at: headerIndex)
 
         let elements = generators.enumerated().map {
             ($0.element, headerIndex, $0.offset)
@@ -166,6 +167,7 @@ public class ManualTableManager: BaseTableManager {
                             generators: [TableCellGenerator],
                             with animation: TableRowAnimation = .animated(.automatic)) {
         let headerIndex = getIndexOf(headGenerator: sectionHeader, after: headerGenerator)
+        self.sections.insert(sectionHeader, at: headerIndex)
 
         let elements = generators.enumerated().map { item in
             (item.element, headerIndex, item.offset)

--- a/Source/Table/Manager/ManualTableManager.swift
+++ b/Source/Table/Manager/ManualTableManager.swift
@@ -336,7 +336,6 @@ public class ManualTableManager: BaseTableManager {
                             new sectionHeader: TableHeaderGenerator,
                             generators: [TableCellGenerator],
                             with animation: UITableView.RowAnimation) {
-
         self.insertSection(after: headerGenerator,
                            new: sectionHeader,
                            generators: generators,
@@ -354,64 +353,42 @@ public class ManualTableManager: BaseTableManager {
     open func insert(before generator: TableCellGenerator,
                      new newGenerators: [TableCellGenerator],
                      with animation: UITableView.RowAnimation) {
-        guard let index = self.findGenerator(generator) else { return }
-        let elements = newGenerators.enumerated().map { item in
-            (item.element, index.sectionIndex, index.generatorIndex + item.offset)
-        }
-        self.insert(elements: elements, with: .animated(animation))
+        self.insert(before: generator, new: newGenerators, with: .animated(animation))
     }
 
     @available(*, deprecated, message: "Please use method with a new `TableRowAnimation` parameter")
     open func insert(after generator: TableCellGenerator,
                      new newGenerator: TableCellGenerator,
                      with animation: UITableView.RowAnimation) {
-        guard let index = self.findGenerator(generator) else { return }
-        self.insert(elements: [(newGenerator, index.sectionIndex, index.generatorIndex + 1)], with: .animated(animation))
+        self.insert(after: generator, new: [newGenerator], with: .animated(animation))
     }
 
     @available(*, deprecated, message: "Please use method with a new `TableRowAnimation` parameter")
     open func insert(before generator: TableCellGenerator,
                      new newGenerator: TableCellGenerator,
                      with animation: UITableView.RowAnimation) {
-        guard let index = self.findGenerator(generator) else { return }
-        self.insert(elements: [(newGenerator, index.sectionIndex, index.generatorIndex)], with: .animated(animation))
+        self.insert(before: generator, new: [newGenerator], with: .animated(animation))
     }
 
     @available(*, deprecated, message: "Please use method with a new `TableRowAnimation` parameter")
     open func insert(to headerGenerator: TableHeaderGenerator,
                      new generator: TableCellGenerator,
                      with animation: UITableView.RowAnimation) {
-        guard let headerIndex = self.sections.firstIndex(where: { $0 === headerGenerator }) else {
-            return
-        }
-        self.insert(elements: [(generator, headerIndex, 0)], with: .animated(animation))
+        self.insert(to: headerGenerator, new: generator, with: .animated(animation))
     }
 
     @available(*, deprecated, message: "Please use method with a new `TableRowAnimation` parameter")
     open func insertAtBeginning(to headerGenerator: TableHeaderGenerator,
                                 new generators: [TableCellGenerator],
                                 with animation: UITableView.RowAnimation) {
-        guard let headerIndex = self.sections.firstIndex(where: { $0 === headerGenerator }) else {
-            return
-        }
-        let elements = generators.enumerated().map { item in
-            (item.element, headerIndex, item.offset)
-        }
-        self.insert(elements: elements, with: .animated(animation))
+        self.insertAtBeginning(to: headerGenerator, new: generators, with: .animated(animation))
     }
 
     @available(*, deprecated, message: "Please use method with a new `TableRowAnimation` parameter")
     open func insertAtEnd(to headerGenerator: TableHeaderGenerator,
                           new generators: [TableCellGenerator],
                           with animation: UITableView.RowAnimation) {
-        guard let headerIndex = self.sections.firstIndex(where: { $0 === headerGenerator }) else {
-            return
-        }
-        let base = self.generators[headerIndex].count
-        let elements = generators.enumerated().map { item in
-            (item.element, headerIndex, base + item.offset)
-        }
-        self.insert(elements: elements, with: .animated(animation))
+        self.insertAtEnd(to: headerGenerator, new: generators, with: .animated(animation))
     }
 
     @available(*, deprecated, message: "Please use method with a new `TableRowAnimationGroup` parameter")
@@ -419,13 +396,9 @@ public class ManualTableManager: BaseTableManager {
                       on newGenerator: TableCellGenerator,
                       removeAnimation: UITableView.RowAnimation,
                       insertAnimation: UITableView.RowAnimation) {
-        guard let index = self.findGenerator(oldGenerator) else { return }
-
-        generators[index.sectionIndex].remove(at: index.generatorIndex)
-        generators[index.sectionIndex].insert(newGenerator, at: index.generatorIndex)
-        let indexPath = IndexPath(row: index.generatorIndex, section: index.sectionIndex)
-
-        modifier?.replace(at: indexPath, with: (remove: removeAnimation, insert: insertAnimation))
+        self.replace(oldGenerator: oldGenerator,
+                     on: newGenerator,
+                     removeInsertAnimation: .animated(removeAnimation, insertAnimation))
     }
 
 }

--- a/Source/Table/Modifier/TableCommonModifier.swift
+++ b/Source/Table/Modifier/TableCommonModifier.swift
@@ -83,10 +83,29 @@ class TableCommonModifier: Modifier<UITableView, UITableView.RowAnimation> {
         }
     }
 
+    /// Insert new sections with rows at specific position with animation
+    ///
+    /// - parameter indexDictionary: dictionary where **key** is new section index and value is location of subviews to insert
+    /// - parameter insertAnimation: animation of insert operation
+    override func insertSectionsAndRows(at indexDictionary: [Int : [IndexPath]],
+                                        with insertAnimation: UITableView.RowAnimation?) {
+        guard let view = view else { return }
+        animator?.perform(in: view, animated: insertAnimation != nil) { [weak view] in
+            let numberOfSections = view?.numberOfSections ?? 0
+            let setOfKeys = IndexSet(indexDictionary.keys.filter { $0 >= numberOfSections })
+            let allValues = indexDictionary.values.flatMap { $0 }
+            if !setOfKeys.isEmpty {
+                view?.insertSections(setOfKeys, with: insertAnimation ?? .none)
+            }
+            view?.insertRows(at: allValues, with: insertAnimation ?? .none)
+        }
+    }
+
     /// Insert sections with animation
     ///
     /// - parameter indexPaths: indexes of inserted sections
     /// - parameter insertAnimation: animation of inserted sections
+    ///  - Warning: This method will insert an **empty** section only. If you need to insert section with rows use `insertSectionsAndRows` instead.
     override func insertSections(at indexPaths: IndexSet, with insertAnimation: UITableView.RowAnimation?) {
         guard let view = view else { return }
         animator?.perform(in: view, animated: insertAnimation != nil) { [weak view] in

--- a/Source/Table/Modifier/TableCommonModifier.swift
+++ b/Source/Table/Modifier/TableCommonModifier.swift
@@ -87,7 +87,7 @@ class TableCommonModifier: Modifier<UITableView, UITableView.RowAnimation> {
     ///
     /// - parameter indexDictionary: dictionary where **key** is new section index and value is location of subviews to insert
     /// - parameter insertAnimation: animation of insert operation
-    override func insertSectionsAndRows(at indexDictionary: [Int : [IndexPath]],
+    override func insertSectionsAndRows(at indexDictionary: [Int: [IndexPath]],
                                         with insertAnimation: UITableView.RowAnimation?) {
         guard let view = view else { return }
         animator?.perform(in: view, animated: insertAnimation != nil) { [weak view] in

--- a/Source/Table/Modifier/TableCommonModifier.swift
+++ b/Source/Table/Modifier/TableCommonModifier.swift
@@ -91,13 +91,11 @@ class TableCommonModifier: Modifier<UITableView, UITableView.RowAnimation> {
                                         with insertAnimation: UITableView.RowAnimation?) {
         guard let view = view else { return }
         animator?.perform(in: view, animated: insertAnimation != nil) { [weak view] in
-            let numberOfSections = view?.numberOfSections ?? 0
-            let setOfKeys = IndexSet(indexDictionary.keys.filter { $0 >= numberOfSections })
+            let setOfKeys = IndexSet(indexDictionary.keys)
             let allValues = indexDictionary.values.flatMap { $0 }
-            if !setOfKeys.isEmpty {
-                view?.insertSections(setOfKeys, with: insertAnimation ?? .none)
-            }
+            view?.insertSections(setOfKeys, with: insertAnimation ?? .none)
             view?.insertRows(at: allValues, with: insertAnimation ?? .none)
+
         }
     }
 

--- a/Source/Table/Modifier/TableCommonModifier.swift
+++ b/Source/Table/Modifier/TableCommonModifier.swift
@@ -87,6 +87,8 @@ class TableCommonModifier: Modifier<UITableView, UITableView.RowAnimation> {
     ///
     /// - parameter indexDictionary: dictionary where **key** is new section index and value is location of subviews to insert
     /// - parameter insertAnimation: animation of insert operation
+    ///  - Warning: make sure that you do not have mistake in indexes inside `indexDictionary`.
+    ///  For example, if you are inserting **many sections** using this method you should notice that **index** cannot be greater than **final number of sections**.
     override func insertSectionsAndRows(at indexDictionary: [Int: [IndexPath]],
                                         with insertAnimation: UITableView.RowAnimation?) {
         guard let view = view else { return }
@@ -95,7 +97,6 @@ class TableCommonModifier: Modifier<UITableView, UITableView.RowAnimation> {
             let allValues = indexDictionary.values.flatMap { $0 }
             view?.insertSections(setOfKeys, with: insertAnimation ?? .none)
             view?.insertRows(at: allValues, with: insertAnimation ?? .none)
-
         }
     }
 

--- a/Source/Table/Modifier/TableDiffableModifier.swift
+++ b/Source/Table/Modifier/TableDiffableModifier.swift
@@ -91,7 +91,7 @@ class TableDiffableModifier: Modifier<UITableView, UITableView.RowAnimation> {
     /// - parameter insertAnimation:
     ///     - **allowed** nil to disable animation
     ///     - **ignored** any other, because automatically selected by `UITableDiffableDataSource`
-    override func insertSectionsAndRows(at indexDictionary: [Int : [IndexPath]],
+    override func insertSectionsAndRows(at indexDictionary: [Int: [IndexPath]],
                                         with insertAnimation: UITableView.RowAnimation?) {
         apply(animated: insertAnimation != nil)
     }

--- a/Source/Table/Modifier/TableDiffableModifier.swift
+++ b/Source/Table/Modifier/TableDiffableModifier.swift
@@ -85,6 +85,17 @@ class TableDiffableModifier: Modifier<UITableView, UITableView.RowAnimation> {
         apply(animated: animation != nil)
     }
 
+    /// Insert new sections with rows at specific position with animation
+    ///
+    /// - parameter indexDictionary: **ignored**, automatically calculated using `DiffableSnapshot`
+    /// - parameter insertAnimation:
+    ///     - **allowed** nil to disable animation
+    ///     - **ignored** any other, because automatically selected by `UITableDiffableDataSource`
+    override func insertSectionsAndRows(at indexDictionary: [Int : [IndexPath]],
+                                        with insertAnimation: UITableView.RowAnimation?) {
+        apply(animated: insertAnimation != nil)
+    }
+
     /// Update snapshot after sections inserted
     ///
     /// - parameter indexPaths: **ignored**, automatically calculated using `DiffableSnapshot`


### PR DESCRIPTION
## Что сделано?

- Исправлено падение в `ManualTableManager.insert`
- В `Modifier` добавлен метод для добавления непустых секций `insertSectionsAndRows`
- ...

## Зачем это сделано?

По заявке с проекта,  на котором было замечено падение.

## На что обратить внимание?

- Затронуто 3 метода вставки 
  - insert at
  - insert after
  - insert before
- ...

## Как протестировать?

- Проверить работу примеров `Table with foldable cell`, `Collection with foldable cell`
- В примере `Table with all Plugins` есть вставка секции. Можно в коде менять якорный генератор и сам метод вставки.
