### PR TITLE
Fix codecov uploader failures

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Upload Coverage
       uses: codecov/codecov-action@v3.1.4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: build/reports/cobertura.xml
         flags: unittests
         name: codecov-unit
@@ -47,6 +48,7 @@ jobs:
     - name: Upload Coverage
       uses: codecov/codecov-action@v3.1.4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: build/reports/cobertura.xml
         flags: uitests
         name: codecov-ui


### PR DESCRIPTION
## Что сделано?

- Добавлен токен для codecov
- ...

## Зачем это сделано?

Чтобы не было плавающих падений на CI

![Снимок экрана 2023-07-18 в 15 15 04](https://github.com/surfstudio/ReactiveDataDisplayManager/assets/28707156/3f3e38b1-e12a-4b2b-aee4-51ee47362451)

## Как протестировать?

- Успех в buildChecks
