### PR TITLE
Bugfix/spt 1564/register at insert

### DIFF
--- a/Example/targets/template.yml
+++ b/Example/targets/template.yml
@@ -36,7 +36,7 @@ targetTemplates:
       settings:
         base:
           PRODUCT_BUNDLE_IDENTIFIER: ${bundle_id}
-          MARKETING_VERSION: "7.3.7"
+          MARKETING_VERSION: "7.3.8"
           CURRENT_PROJECT_VERSION: 0
           VERSIONING_SYSTEM: "apple-generic"
           DEBUG_INFORMATION_FORMAT: dwarf-with-dsym

--- a/ReactiveDataDisplayManager.podspec
+++ b/ReactiveDataDisplayManager.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "ReactiveDataDisplayManager"
-  s.version = "7.3.7"
+  s.version = "7.3.8"
   s.summary = "Library with custom events and reusable adapter for scrollable UI Collections"
   s.homepage = "https://github.com/surfstudio/ReactiveDataDisplayManager"
   s.license = "MIT"

--- a/Source/Collection/Manager/BaseCollectionManager.swift
+++ b/Source/Collection/Manager/BaseCollectionManager.swift
@@ -218,12 +218,12 @@ private extension BaseCollectionManager {
 
     func insert(elements: [(generator: CollectionCellGenerator, sectionIndex: Int, generatorIndex: Int)]) {
 
-        elements.forEach { [weak self] element in
+        elements.forEach { element in
             element.generator.registerCell(in: view)
-            if self?.generators.count == element.sectionIndex {
-                self?.generators.append([element.generator])
+            if self.generators.count == element.sectionIndex {
+                self.generators.append([element.generator])
             } else {
-                self?.generators[element.sectionIndex].insert(element.generator, at: element.generatorIndex)
+                self.generators[element.sectionIndex].insert(element.generator, at: element.generatorIndex)
             }
         }
 

--- a/Source/Table/Manager/BaseTableManager.swift
+++ b/Source/Table/Manager/BaseTableManager.swift
@@ -190,9 +190,9 @@ extension BaseTableManager {
     func insert(elements: [(generator: TableCellGenerator, sectionIndex: Int, generatorIndex: Int)],
                 with animation: TableRowAnimation) {
 
-        elements.forEach { [weak self] element in
+        elements.forEach { element in
             element.generator.registerCell(in: view)
-            self?.generators[element.sectionIndex].insert(element.generator, at: element.generatorIndex)
+            self.generators[element.sectionIndex].insert(element.generator, at: element.generatorIndex)
         }
 
         let indexPaths = elements.map { IndexPath(row: $0.generatorIndex, section: $0.sectionIndex) }

--- a/Source/Table/Manager/ManualTableManager.swift
+++ b/Source/Table/Manager/ManualTableManager.swift
@@ -442,6 +442,10 @@ private extension ManualTableManager {
                 at sectionIndex: Int,
                 with animation: TableRowAnimation) {
 
+        generators.forEach {
+            $0.registerCell(in: view)
+        }
+
         self.sections.insert(header, at: sectionIndex)
         self.generators.insert(generators, at: sectionIndex)
 

--- a/project.yml
+++ b/project.yml
@@ -36,7 +36,7 @@ targets:
       settings:
         base:
           PRODUCT_BUNDLE_IDENTIFIER: ru.surfstudio.rddm
-          MARKETING_VERSION: "7.3.7"
+          MARKETING_VERSION: "7.3.8"
           CURRENT_PROJECT_VERSION: 0
           VERSIONING_SYSTEM: "apple-generic"
           DEBUG_INFORMATION_FORMAT: dwarf-with-dsym


### PR DESCRIPTION
## Что сделано?

- Добавлена регистрация для ячеек при вставке секции методами `insertSection`
- Исправлены  warnings по Swift 6
- Поднята версия
- ...

## Зачем это сделано?

Чтобы избежать ошибки
> "unable to dequeue a cell with identifier OnlineBankOperationHistoryCell - must register a nib or a class for the identifier or connect a prototype cell in a storyboard"

При вставке нового типа ячейки в секцию методом `insertSection`

## Как протестировать?

- Проверить на проблемном участке проекта
