### PR TITLE
Fix PluginChecker async issue

### DIFF
--- a/Source/Collection/Plugins/CollectionPluginsChecker.swift
+++ b/Source/Collection/Plugins/CollectionPluginsChecker.swift
@@ -38,7 +38,9 @@ final class CollectionPluginsChecker {
     /// For selectable plugin. Since it is connected basicly, you need to check the events
     ///
     func checkPlugin(for generator: SelectableItem?) {
-        let plugin = delegate?.collectionPlugins.plugins.first(where: { $0 is CollectionSelectablePlugin })
+        guard let delegate = delegate else { return }
+
+        let plugin = delegate.collectionPlugins.plugins.first(where: { $0 is CollectionSelectablePlugin })
         let eventsNotEmpty = generator?.didSelectEvent.isEmpty == false || generator?.didDeselectEvent.isEmpty == false
 
         guard generator != nil && plugin == nil && eventsNotEmpty else { return }
@@ -51,7 +53,9 @@ final class CollectionPluginsChecker {
     ///   - pluginName: The name of the plugin using the specified ability item
     ///
     func checkPlugin(for generator: AnyObject?, pluginName: String) {
-        let plugin = delegate?.collectionPlugins.plugins.first(where: { $0.pluginName == pluginName })
+        guard let delegate = delegate else { return }
+
+        let plugin = delegate.collectionPlugins.plugins.first(where: { $0.pluginName == pluginName })
 
         guard generator != nil && plugin == nil else { return }
         assertionFailure("❗️Include the \(pluginName).")

--- a/Source/Table/Plugins/TablePluginsChecker.swift
+++ b/Source/Table/Plugins/TablePluginsChecker.swift
@@ -38,7 +38,9 @@ final class TablePluginsChecker {
     /// For selectable plugin. Since it is connected basicly, you need to check the events
     ///
     func checkPlugin(for generator: SelectableItem?) {
-        let plugin = delegate?.tablePlugins.plugins.first(where: { $0 is TableSelectablePlugin })
+        guard let delegate = delegate else { return }
+
+        let plugin = delegate.tablePlugins.plugins.first(where: { $0 is TableSelectablePlugin })
         let eventsNotEmpty = generator?.didSelectEvent.isEmpty == false || generator?.didDeselectEvent.isEmpty == false
 
         guard generator != nil && plugin == nil && eventsNotEmpty else { return }
@@ -51,7 +53,9 @@ final class TablePluginsChecker {
     ///   - pluginName: The name of the plugin using the specified ability item
     ///
     func checkPlugin(for generator: AnyObject?, pluginName: String) {
-        let plugin = delegate?.tablePlugins.plugins.first(where: { $0.pluginName == pluginName })
+        guard let delegate = delegate else { return }
+
+        let plugin = delegate.tablePlugins.plugins.first(where: { $0.pluginName == pluginName })
 
         guard generator != nil && plugin == nil else { return }
         assertionFailure("❗️Include the \(pluginName).")


### PR DESCRIPTION
## Что сделано?

Добавлена проверка `delegate != nil` в PluginChecker

## Зачем это сделано?

Ссылка на `delegate` слабая, а `checkPlugins()` вызывается асинхронно. Поэтому иногда получалось, что `delegate` удалялся до завершения `checkPlugins` и получался AssertionFailure.

## На что обратить внимание?

- Продублировал проверку в CollectionPluginsChecker и TablePluginsChecker, так как поведение у них одинаковое
- Под этот фикс создана ветка release/7.3.9,  ПР направлен в неё

Resolves #255 
